### PR TITLE
Bugfix/test activation

### DIFF
--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -14,7 +14,11 @@ class Tensor:
         else:
             self.data = np.array(data)
         self.requires_grad = requires_grad
-        self.grad = np.zeros_like(self.data) if requires_grad else None
+        # if requires_grad is True, then we need to initialize the gradient to zeros
+        # and make sure that they're floats, since backprop uses floats
+        self.grad = (
+            np.zeros_like(self.data, dtype=np.float64) if requires_grad else None
+        )
         self.context = None
 
     @property

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -66,7 +66,7 @@ class Tensor:
             if tensor.context is not None:
                 grads = tensor.context.op.backward(tensor.context, grad)
                 for arg, grad_arg in zip(tensor.context.args, grads):
-                    if isinstance(arg, Tensor):
+                    if isinstance(arg, Tensor) and arg.requires_grad:
                         arg.grad += grad_arg
                         stack.append((arg, grad_arg))
 

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -4,7 +4,7 @@ from punytorch.tensor import Tensor
 
 
 def test_ReLU():
-    x = Tensor(np.array([-2, -1, 0, 1, 2]))
+    x = Tensor(np.array([-2, -1, 0, 1, 2]), requires_grad=True)
     y = x.relu()
     assert np.all(y.data == np.array([0, 0, 0, 1, 2]))
     y.backward(np.ones_like(x.data))
@@ -12,7 +12,7 @@ def test_ReLU():
 
 
 def test_Sigmoid():
-    x = Tensor(np.array([0, 1, 2, 3, 4, 5]))
+    x = Tensor(np.array([0, 1, 2, 3, 4, 5]), requires_grad=True)
     y = x.sigmoid()
     assert np.allclose(y.data, 1 / (1 + np.exp(-x.data)))
     y.backward()


### PR DESCRIPTION
Added a few changes to make sure that our tests/test_activation.py test functions were passing.

We had to:

- ensure that `self.grad` was forced to initialize as floats, since that is the datatype used during back propogation
- ensure that the tensors being created in the `test_activation` functions required their gradients to be computed by setting `requires_grad=True`
- add a condition to our `backward` method in the `Tensor` class that would only accumulate the gradient if `requires_grad` was set to `True`