### PR TITLE
[codex] Refactor autograd contract

### DIFF
--- a/punytorch/activations.py
+++ b/punytorch/activations.py
@@ -2,14 +2,6 @@ import numpy as np
 from punytorch.ops import Operation
 
 
-def _data(value):
-    return value.data if hasattr(value, "data") else value
-
-
-def _grad_data(value):
-    return np.asarray(_data(value), dtype=np.float64)
-
-
 class ReLU(Operation):
     """
     Implements the ReLU (Rectified Linear Unit) activation function for a neural network.
@@ -26,7 +18,7 @@ class ReLU(Operation):
         Returns:
             numpy.ndarray: The output after applying the ReLU function, which is max(0, x).
         """
-        return np.maximum(0, _data(x))
+        return np.maximum(0, x)
 
     @staticmethod
     def backward(context, grad):
@@ -43,7 +35,7 @@ class ReLU(Operation):
         """
         x = context.args[0].data
         # grad wasn't broadcasting to the same shape as x, so:
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         grad_data = np.ones_like(x) if np.isscalar(grad_data) else grad_data
         return ((x > 0).astype(np.float64) * grad_data,)
 
@@ -64,8 +56,7 @@ class Sigmoid(Operation):
         Returns:
             numpy.ndarray: The output after applying the Sigmoid function, which is 1 / (1 + exp(-x)).
         """
-        input_data = _data(x)
-        return 1 / (1 + np.exp(-input_data))
+        return 1 / (1 + np.exp(-x))
 
     @staticmethod
     def backward(context, grad):
@@ -82,7 +73,7 @@ class Sigmoid(Operation):
         """
         x = context.args[0].data
         sigmoid_x = 1 / (1 + np.exp(-x))
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return (sigmoid_x * (1 - sigmoid_x) * grad_data,)
 
 
@@ -106,10 +97,7 @@ class Softmax(Operation):
         """
         if dim is None:
             dim = -1
-        input_data = _data(x)
-        e_x = np.exp(
-            input_data - np.max(input_data, axis=dim, keepdims=True)
-        )  # subtract max(x) for numerical stability
+        e_x = np.exp(x - np.max(x, axis=dim, keepdims=True))  # subtract max(x) for numerical stability
         return e_x / np.sum(e_x, axis=dim, keepdims=True)
 
     @staticmethod
@@ -131,9 +119,7 @@ class Softmax(Operation):
         """
         x, dim = context.args
         dim = -1 if dim is None else dim
-        softmax_x = Softmax.forward(x, dim=dim)
-        grad_data = _grad_data(grad)
-        grad_input = softmax_x * (
-            grad_data - np.sum(grad_data * softmax_x, axis=dim, keepdims=True)
-        )
+        softmax_x = Softmax.forward(x.data, dim=dim)
+        grad_data = np.asarray(grad, dtype=np.float64)
+        grad_input = softmax_x * (grad_data - np.sum(grad_data * softmax_x, axis=dim, keepdims=True))
         return grad_input, None

--- a/punytorch/activations.py
+++ b/punytorch/activations.py
@@ -2,6 +2,14 @@ import numpy as np
 from punytorch.ops import Operation
 
 
+def _data(value):
+    return value.data if hasattr(value, "data") else value
+
+
+def _grad_data(value):
+    return np.asarray(_data(value), dtype=np.float64)
+
+
 class ReLU(Operation):
     """
     Implements the ReLU (Rectified Linear Unit) activation function for a neural network.
@@ -18,7 +26,7 @@ class ReLU(Operation):
         Returns:
             numpy.ndarray: The output after applying the ReLU function, which is max(0, x).
         """
-        return np.maximum(0, x.data)
+        return np.maximum(0, _data(x))
 
     @staticmethod
     def backward(context, grad):
@@ -33,13 +41,11 @@ class ReLU(Operation):
             tuple: A tuple where the first element is the gradient of the loss with respect to the input,
                    and the second element is None (since ReLU has no parameters to update).
         """
-        from punytorch.tensor import Tensor
-
         x = context.args[0].data
         # grad wasn't broadcasting to the same shape as x, so:
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
+        grad_data = _grad_data(grad)
         grad_data = np.ones_like(x) if np.isscalar(grad_data) else grad_data
-        return Tensor((x > 0).astype(np.float64) * grad_data), None
+        return ((x > 0).astype(np.float64) * grad_data,)
 
 
 class Sigmoid(Operation):
@@ -58,7 +64,8 @@ class Sigmoid(Operation):
         Returns:
             numpy.ndarray: The output after applying the Sigmoid function, which is 1 / (1 + exp(-x)).
         """
-        return 1 / (1 + np.exp(-x.data))
+        input_data = _data(x)
+        return 1 / (1 + np.exp(-input_data))
 
     @staticmethod
     def backward(context, grad):
@@ -73,12 +80,10 @@ class Sigmoid(Operation):
             tuple: A tuple where the first element is the gradient of the loss with respect to the input,
                    and the second element is None (since Sigmoid has no parameters to update).
         """
-        from punytorch.tensor import Tensor
-
         x = context.args[0].data
         sigmoid_x = 1 / (1 + np.exp(-x))
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
-        return Tensor(sigmoid_x * (1 - sigmoid_x) * grad_data), None
+        grad_data = _grad_data(grad)
+        return (sigmoid_x * (1 - sigmoid_x) * grad_data,)
 
 
 class Softmax(Operation):
@@ -101,7 +106,7 @@ class Softmax(Operation):
         """
         if dim is None:
             dim = -1
-        input_data = x.data if hasattr(x, "data") else x
+        input_data = _data(x)
         e_x = np.exp(
             input_data - np.max(input_data, axis=dim, keepdims=True)
         )  # subtract max(x) for numerical stability
@@ -124,18 +129,11 @@ class Softmax(Operation):
         Returns:
             numpy.ndarray: The gradient of the loss with respect to the input.
         """
-        from punytorch.tensor import Tensor
-
-        x = context.args[0].data
-        softmax_x = np.exp(x - np.max(x))
-        softmax_x /= np.sum(softmax_x, axis=0)
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
-        grad_data = np.ones_like(x) if np.isscalar(grad_data) else grad_data
-        grad_input = np.zeros_like(x)
-        for i in range(len(x)):
-            for j in range(len(x)):
-                if i == j:
-                    grad_input[i] += grad_data[j] * softmax_x[i] * (1 - softmax_x[j])
-                else:
-                    grad_input[i] -= grad_data[j] * softmax_x[i] * softmax_x[j]
-        return Tensor(grad_input), None
+        x, dim = context.args
+        dim = -1 if dim is None else dim
+        softmax_x = Softmax.forward(x, dim=dim)
+        grad_data = _grad_data(grad)
+        grad_input = softmax_x * (
+            grad_data - np.sum(grad_data * softmax_x, axis=dim, keepdims=True)
+        )
+        return grad_input, None

--- a/punytorch/losses.py
+++ b/punytorch/losses.py
@@ -4,6 +4,14 @@ from punytorch.tensor import Tensor
 from punytorch.ops import Operation
 
 
+def _data(value):
+    return value.data if hasattr(value, "data") else value
+
+
+def _grad_data(value):
+    return np.asarray(_data(value), dtype=np.float64)
+
+
 class MSELoss(Operation):
     """
     Implements the Mean Squared Error (MSE) loss function for a neural network.
@@ -21,7 +29,7 @@ class MSELoss(Operation):
         Returns:
             float: The MSE loss, which is the mean of the squared differences between the predicted and true values.
         """
-        loss = np.mean((y_pred.data - y_true.data) ** 2)
+        loss = np.mean((_data(y_pred) - _data(y_true)) ** 2)
         return loss
 
     @staticmethod
@@ -38,8 +46,8 @@ class MSELoss(Operation):
         """
         y_pred, y_true = context.args
         grad_pred = 2 * (y_pred.data - y_true.data) / y_pred.data.size
-        grad_data = grad.data if hasattr(grad, "data") else grad
-        return Tensor(grad_pred * grad_data), None
+        grad_data = _grad_data(grad)
+        return grad_pred * grad_data, None
 
 
 class CrossEntropyLoss(Operation):
@@ -60,8 +68,14 @@ class CrossEntropyLoss(Operation):
         Returns:
             float: Scalar loss value
         """
+        logits_data = _data(logits)
+        targets_data = _data(targets)
+        if logits_data.ndim == 1:
+            logits_data = logits_data.reshape(1, -1)
+            targets_data = targets_data.reshape(1, -1)
+
         # Numerical stability: Subtract max logit (prevents exp overflow)
-        shifted_logits = logits.data - np.max(logits.data, axis=1, keepdims=True)
+        shifted_logits = logits_data - np.max(logits_data, axis=1, keepdims=True)
 
         # Log-softmax implementation
         exp_logits = np.exp(shifted_logits)
@@ -69,7 +83,7 @@ class CrossEntropyLoss(Operation):
         log_softmax = shifted_logits - log_sum_exp
 
         # Cross entropy is negative sum of true_probs * log_probs
-        batch_losses = -np.sum(targets.data * log_softmax, axis=1)
+        batch_losses = -np.sum(targets_data * log_softmax, axis=1)
         loss = np.mean(batch_losses)
 
         return loss
@@ -88,17 +102,25 @@ class CrossEntropyLoss(Operation):
         """
         logits, targets = context.args
 
+        logits_data = logits.data
+        targets_data = targets.data
+        original_shape = logits_data.shape
+        if logits_data.ndim == 1:
+            logits_data = logits_data.reshape(1, -1)
+            targets_data = targets_data.reshape(1, -1)
+
         # Compute softmax (reuse the stability trick)
-        shifted_logits = logits.data - np.max(logits.data, axis=1, keepdims=True)
+        shifted_logits = logits_data - np.max(logits_data, axis=1, keepdims=True)
         exp_logits = np.exp(shifted_logits)
         softmax = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
 
         # Gradient is (softmax - targets) / batch_size
-        batch_size = logits.shape[0]
-        grad_logits = (softmax - targets.data) / batch_size
+        batch_size = logits_data.shape[0]
+        grad_logits = (softmax - targets_data) / batch_size
+        grad_logits = grad_logits.reshape(original_shape)
 
         # Scale by upstream gradient and return as Tensor
-        return Tensor(grad_logits * grad.data), None
+        return grad_logits * _grad_data(grad), None
 
 
 class BinaryCrossEntropyLoss(Operation):
@@ -120,10 +142,12 @@ class BinaryCrossEntropyLoss(Operation):
         """
         # Add small epsilon for numerical stability
         epsilon = 1e-15
-        y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
+        y_pred_data = _data(y_pred)
+        y_true_data = _data(y_true)
+        y_pred_clipped = np.clip(y_pred_data, epsilon, 1 - epsilon)
         loss = -np.mean(
-            y_true.data * np.log(y_pred_clipped)
-            + (1 - y_true.data) * np.log(1 - y_pred_clipped)
+            y_true_data * np.log(y_pred_clipped)
+            + (1 - y_true_data) * np.log(1 - y_pred_clipped)
         )
         return loss
 
@@ -145,8 +169,8 @@ class BinaryCrossEntropyLoss(Operation):
         grad_pred = (y_pred_clipped - y_true.data) / (
             y_pred_clipped * (1 - y_pred_clipped)
         )
-        grad_data = grad.data if hasattr(grad, "data") else grad
-        return Tensor(grad_pred * grad_data / y_pred.data.size), None
+        grad_data = _grad_data(grad)
+        return grad_pred * grad_data / y_pred.data.size, None
 
 
 class CategoricalCrossEntropyLoss(Operation):
@@ -168,8 +192,8 @@ class CategoricalCrossEntropyLoss(Operation):
         """
         # Add small epsilon for numerical stability
         epsilon = 1e-15
-        y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
-        loss = -np.sum(y_true.data * np.log(y_pred_clipped))
+        y_pred_clipped = np.clip(_data(y_pred), epsilon, 1 - epsilon)
+        loss = -np.sum(_data(y_true) * np.log(y_pred_clipped))
         return loss
 
     @staticmethod
@@ -188,5 +212,5 @@ class CategoricalCrossEntropyLoss(Operation):
         epsilon = 1e-15
         y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
         grad_pred = -y_true.data / y_pred_clipped
-        grad_data = grad.data if hasattr(grad, "data") else grad
-        return Tensor(grad_pred * grad_data), None
+        grad_data = _grad_data(grad)
+        return grad_pred * grad_data, None

--- a/punytorch/losses.py
+++ b/punytorch/losses.py
@@ -1,15 +1,6 @@
 import numpy as np
 
-from punytorch.tensor import Tensor
 from punytorch.ops import Operation
-
-
-def _data(value):
-    return value.data if hasattr(value, "data") else value
-
-
-def _grad_data(value):
-    return np.asarray(_data(value), dtype=np.float64)
 
 
 class MSELoss(Operation):
@@ -18,7 +9,7 @@ class MSELoss(Operation):
     """
 
     @staticmethod
-    def forward(y_pred: Tensor, y_true: Tensor) -> float:
+    def forward(y_pred, y_true) -> float:
         """
         Computes the forward pass of the MSE loss function.
 
@@ -29,7 +20,7 @@ class MSELoss(Operation):
         Returns:
             float: The MSE loss, which is the mean of the squared differences between the predicted and true values.
         """
-        loss = np.mean((_data(y_pred) - _data(y_true)) ** 2)
+        loss = np.mean((y_pred - y_true) ** 2)
         return loss
 
     @staticmethod
@@ -46,7 +37,7 @@ class MSELoss(Operation):
         """
         y_pred, y_true = context.args
         grad_pred = 2 * (y_pred.data - y_true.data) / y_pred.data.size
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return grad_pred * grad_data, None
 
 
@@ -57,7 +48,7 @@ class CrossEntropyLoss(Operation):
     """
 
     @staticmethod
-    def forward(logits: Tensor, targets: Tensor) -> float:
+    def forward(logits, targets) -> float:
         """
         Computes cross entropy loss from raw logits.
 
@@ -68,14 +59,12 @@ class CrossEntropyLoss(Operation):
         Returns:
             float: Scalar loss value
         """
-        logits_data = _data(logits)
-        targets_data = _data(targets)
-        if logits_data.ndim == 1:
-            logits_data = logits_data.reshape(1, -1)
-            targets_data = targets_data.reshape(1, -1)
+        if logits.ndim == 1:
+            logits = logits.reshape(1, -1)
+            targets = targets.reshape(1, -1)
 
         # Numerical stability: Subtract max logit (prevents exp overflow)
-        shifted_logits = logits_data - np.max(logits_data, axis=1, keepdims=True)
+        shifted_logits = logits - np.max(logits, axis=1, keepdims=True)
 
         # Log-softmax implementation
         exp_logits = np.exp(shifted_logits)
@@ -83,13 +72,13 @@ class CrossEntropyLoss(Operation):
         log_softmax = shifted_logits - log_sum_exp
 
         # Cross entropy is negative sum of true_probs * log_probs
-        batch_losses = -np.sum(targets_data * log_softmax, axis=1)
+        batch_losses = -np.sum(targets * log_softmax, axis=1)
         loss = np.mean(batch_losses)
 
         return loss
 
     @staticmethod
-    def backward(context, grad: Tensor) -> tuple:
+    def backward(context, grad) -> tuple:
         """
         Computes gradient of loss with respect to logits.
 
@@ -120,7 +109,7 @@ class CrossEntropyLoss(Operation):
         grad_logits = grad_logits.reshape(original_shape)
 
         # Scale by upstream gradient and return as Tensor
-        return grad_logits * _grad_data(grad), None
+        return grad_logits * np.asarray(grad, dtype=np.float64), None
 
 
 class BinaryCrossEntropyLoss(Operation):
@@ -129,7 +118,7 @@ class BinaryCrossEntropyLoss(Operation):
     """
 
     @staticmethod
-    def forward(y_pred: Tensor, y_true: Tensor) -> float:
+    def forward(y_pred, y_true) -> float:
         """
         Computes the forward pass of the Binary Cross Entropy loss function.
 
@@ -142,13 +131,8 @@ class BinaryCrossEntropyLoss(Operation):
         """
         # Add small epsilon for numerical stability
         epsilon = 1e-15
-        y_pred_data = _data(y_pred)
-        y_true_data = _data(y_true)
-        y_pred_clipped = np.clip(y_pred_data, epsilon, 1 - epsilon)
-        loss = -np.mean(
-            y_true_data * np.log(y_pred_clipped)
-            + (1 - y_true_data) * np.log(1 - y_pred_clipped)
-        )
+        y_pred_clipped = np.clip(y_pred, epsilon, 1 - epsilon)
+        loss = -np.mean(y_true * np.log(y_pred_clipped) + (1 - y_true) * np.log(1 - y_pred_clipped))
         return loss
 
     @staticmethod
@@ -166,10 +150,8 @@ class BinaryCrossEntropyLoss(Operation):
         y_pred, y_true = context.args
         epsilon = 1e-15
         y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
-        grad_pred = (y_pred_clipped - y_true.data) / (
-            y_pred_clipped * (1 - y_pred_clipped)
-        )
-        grad_data = _grad_data(grad)
+        grad_pred = (y_pred_clipped - y_true.data) / (y_pred_clipped * (1 - y_pred_clipped))
+        grad_data = np.asarray(grad, dtype=np.float64)
         return grad_pred * grad_data / y_pred.data.size, None
 
 
@@ -179,7 +161,7 @@ class CategoricalCrossEntropyLoss(Operation):
     """
 
     @staticmethod
-    def forward(y_pred: Tensor, y_true: Tensor) -> float:
+    def forward(y_pred, y_true) -> float:
         """
         Computes the forward pass of the Categorical Cross Entropy loss function.
 
@@ -192,8 +174,8 @@ class CategoricalCrossEntropyLoss(Operation):
         """
         # Add small epsilon for numerical stability
         epsilon = 1e-15
-        y_pred_clipped = np.clip(_data(y_pred), epsilon, 1 - epsilon)
-        loss = -np.sum(_data(y_true) * np.log(y_pred_clipped))
+        y_pred_clipped = np.clip(y_pred, epsilon, 1 - epsilon)
+        loss = -np.sum(y_true * np.log(y_pred_clipped))
         return loss
 
     @staticmethod
@@ -212,5 +194,5 @@ class CategoricalCrossEntropyLoss(Operation):
         epsilon = 1e-15
         y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
         grad_pred = -y_true.data / y_pred_clipped
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return grad_pred * grad_data, None

--- a/punytorch/nn/modules.py
+++ b/punytorch/nn/modules.py
@@ -118,7 +118,7 @@ class Module:
                 raise KeyError(f"Key {key} not found in module's state.")
             return child
 
-        def _value_data(value):
+        def _as_array_copy(value):
             if isinstance(value, Tensor):
                 return value.data.copy()
             return np.array(value, copy=True)
@@ -134,7 +134,7 @@ class Module:
                 raise KeyError(f"Key {key} not found in module's state.")
             attr = getattr(root, name)
             if isinstance(attr, Parameter):
-                data = _value_data(value)
+                data = _as_array_copy(value)
                 if attr.data.shape != data.shape:
                     raise ValueError(f"Shape mismatch for {key}: expected {attr.data.shape}, got {data.shape}.")
                 attr.data = data

--- a/punytorch/nn/modules.py
+++ b/punytorch/nn/modules.py
@@ -38,15 +38,28 @@ class Module:
             list[Parameter]: A list of all parameters in the module.
         """
         params = []
-        for key, value in self.__dict__.items():
-            if isinstance(value, Parameter):
-                params.append(value)
-            if isinstance(value, Module):
-                params.extend(value.parameters())
-            if isinstance(value, ModuleList):
-                for module in value:
-                    params.extend(module.parameters())
-        return list(set(params))
+        seen = set()
+
+        def add_parameter(param: Parameter):
+            param_id = id(param)
+            if param_id not in seen:
+                params.append(param)
+                seen.add(param_id)
+
+        def collect(module: Module):
+            if isinstance(module, ModuleList):
+                for child in module:
+                    collect(child)
+                return
+
+            for value in module.__dict__.values():
+                if isinstance(value, Parameter):
+                    add_parameter(value)
+                elif isinstance(value, Module):
+                    collect(value)
+
+        collect(self)
+        return params
 
     def state_dict(self):
         """
@@ -68,17 +81,13 @@ class Module:
                     d[key] = v.clone()
                 elif isinstance(v, ModuleList):
                     ds = [
-                        _get_params(
-                            m, f"{prefix}.{k}.{idx}" if prefix != "" else f"{k}.{idx}"
-                        )
+                        _get_params(m, f"{prefix}.{k}.{idx}" if prefix != "" else f"{k}.{idx}")
                         for idx, m in enumerate(v)
                     ]
                     for x in ds:
                         absorb_dict(d, x)
                 elif isinstance(v, Module):
-                    absorb_dict(
-                        d, _get_params(v, f"{prefix}.{k}" if prefix != "" else f"{k}")
-                    )
+                    absorb_dict(d, _get_params(v, f"{prefix}.{k}" if prefix != "" else f"{k}"))
             return d
 
         return _get_params(self)
@@ -90,17 +99,47 @@ class Module:
         Args:
             state_dict (dict): A dict containing parameters and persistent buffers.
         """
-        for key, value in state_dict.items():
-            attr = getattr(self, key, None)
-            if attr is None:
+
+        def _lookup_child(root, part, key):
+            if isinstance(root, ModuleList):
+                if not part.isdigit():
+                    raise KeyError(f"Key {key} not found in module's state.")
+                index = int(part)
+                try:
+                    return root[index]
+                except IndexError as exc:
+                    raise KeyError(f"Key {key} not found in module's state.") from exc
+
+            if not isinstance(root, Module) or not hasattr(root, part):
                 raise KeyError(f"Key {key} not found in module's state.")
+
+            child = getattr(root, part)
+            if not isinstance(child, (Module, ModuleList)):
+                raise KeyError(f"Key {key} not found in module's state.")
+            return child
+
+        def _value_data(value):
+            if isinstance(value, Tensor):
+                return value.data.copy()
+            return np.array(value, copy=True)
+
+        for key, value in state_dict.items():
+            parts = key.split(".")
+            root = self
+            for part in parts[:-1]:
+                root = _lookup_child(root, part, key)
+
+            name = parts[-1]
+            if not isinstance(root, Module) or not hasattr(root, name):
+                raise KeyError(f"Key {key} not found in module's state.")
+            attr = getattr(root, name)
             if isinstance(attr, Parameter):
-                attr.data = value
-            elif isinstance(attr, Module):
-                attr.load_state_dict(value)
-            elif isinstance(attr, list):  # Assuming ModuleList
-                for param, state in zip(attr, value):
-                    param.load_state_dict(state)
+                data = _value_data(value)
+                if attr.data.shape != data.shape:
+                    raise ValueError(f"Shape mismatch for {key}: expected {attr.data.shape}, got {data.shape}.")
+                attr.data = data
+            else:
+                raise KeyError(f"Key {key} not found in module's state.")
 
     def register_buffer(self, name, value: Tensor):
         """
@@ -173,9 +212,7 @@ class Linear(Module):
         self.in_features = in_features
         self.out_features = out_features
 
-        self.weight = Parameter(
-            np.random.randn(out_features, in_features) * np.sqrt(2.0 / in_features)
-        )
+        self.weight = Parameter(np.random.randn(out_features, in_features) * np.sqrt(2.0 / in_features))
         self.bias = Parameter(np.zeros((out_features,))) if bias else None
 
     def forward(self, x: Tensor) -> Tensor:
@@ -189,7 +226,9 @@ class Linear(Module):
             Tensor: The output of the linear transformation.
         """
         self.input = x
-        x = (x @ self.weight.T) + self.bias
+        x = x @ self.weight.T
+        if self.bias is not None:
+            x = x + self.bias
         return x
 
     def backward(self, grad: Tensor) -> Tensor:

--- a/punytorch/nn/optimizers.py
+++ b/punytorch/nn/optimizers.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from punytorch.tensor import Tensor
+
 
 class Optimizer:
     """
@@ -13,7 +15,19 @@ class Optimizer:
         Args:
             params (iterable): An iterable of Parameters that define what to optimize.
         """
-        self.params = params
+        self.params = list(params)
+
+    @staticmethod
+    def _as_array(value):
+        if isinstance(value, Tensor):
+            return value.data
+        return np.asarray(value)
+
+    @classmethod
+    def _grad_array(cls, param):
+        if param.grad is None:
+            return None
+        return cls._as_array(param.grad)
 
     def zero_grad(self):
         """
@@ -22,8 +36,9 @@ class Optimizer:
         This is typically used when you start to compute gradients for the next optimization step.
         """
         for param in self.params:
-            if param.grad is not None:
-                param.grad = np.zeros_like(param.grad)
+            grad = self._grad_array(param)
+            if grad is not None:
+                param.grad = np.zeros_like(grad)
 
     def step(self):
         """
@@ -62,7 +77,10 @@ class SGD(Optimizer):
         the learning rate times the parameter's gradient.
         """
         for param in self.params:
-            param.data -= self.lr * param.grad
+            grad = self._grad_array(param)
+            if grad is None:
+                continue
+            param.data -= self.lr * grad
 
 
 class Adam(Optimizer):
@@ -102,11 +120,9 @@ class Adam(Optimizer):
         """
         self.t += 1
         for i, param in enumerate(self.params):
-            if param.grad is None:
+            grad_data = self._grad_array(param)
+            if grad_data is None:
                 continue
-            grad_data = np.array(
-                param.grad.data
-            )  # Convert the memoryview to a numpy array
             self.m[i] = self.betas[0] * self.m[i] + (1 - self.betas[0]) * grad_data
             self.v[i] = self.betas[1] * self.v[i] + (1 - self.betas[1]) * (grad_data**2)
             m_hat = self.m[i] / (1 - self.betas[0] ** self.t)
@@ -146,10 +162,11 @@ class RMSProp(Optimizer):
         For each parameter in the list, the parameter's data is updated in-place using the RMSProp update rule.
         """
         for i, param in enumerate(self.params):
-            if param.grad is None:
+            grad = self._grad_array(param)
+            if grad is None:
                 continue
-            self.v[i] = self.alpha * self.v[i] + (1 - self.alpha) * (param.grad**2)
-            param.data -= self.lr * param.grad / (np.sqrt(self.v[i]) + self.eps)
+            self.v[i] = self.alpha * self.v[i] + (1 - self.alpha) * (grad**2)
+            param.data -= self.lr * grad / (np.sqrt(self.v[i]) + self.eps)
 
 
 class Adagrad(Optimizer):
@@ -183,10 +200,11 @@ class Adagrad(Optimizer):
         For each parameter in the list, the parameter's data is updated in-place using the Adagrad update rule.
         """
         for i, param in enumerate(self.params):
-            if param.grad is None:
+            grad = self._grad_array(param)
+            if grad is None:
                 continue
-            self.G[i] += param.grad**2
-            param.data -= self.lr / np.sqrt(self.G[i] + self.eps) * param.grad
+            self.G[i] += grad**2
+            param.data -= self.lr / np.sqrt(self.G[i] + self.eps) * grad
 
 
 class Adadelta(Optimizer):
@@ -221,13 +239,11 @@ class Adadelta(Optimizer):
         For each parameter in the list, the parameter's data is updated in-place using the Adadelta update rule.
         """
         for i, param in enumerate(self.params):
-            if param.grad is None:
+            grad = self._grad_array(param)
+            if grad is None:
                 continue
-            self.Eg[i] = self.rho * self.Eg[i] + (1 - self.rho) * param.grad**2
-            delta = (
-                np.sqrt((self.Edelta[i] + self.eps) / (self.Eg[i] + self.eps))
-                * param.grad
-            )
+            self.Eg[i] = self.rho * self.Eg[i] + (1 - self.rho) * grad**2
+            delta = np.sqrt((self.Edelta[i] + self.eps) / (self.Eg[i] + self.eps)) * grad
             self.Edelta[i] = self.rho * self.Edelta[i] + (1 - self.rho) * delta**2
             param.data -= delta
 
@@ -268,12 +284,9 @@ class Adamax(Optimizer):
         """
         self.t += 1
         for i, param in enumerate(self.params):
-            if param.grad is None:
+            grad = self._grad_array(param)
+            if grad is None:
                 continue
-            self.m[i] = self.betas[0] * self.m[i] + (1 - self.betas[0]) * param.grad
-            self.u[i] = np.maximum(self.betas[1] * self.u[i], np.abs(param.grad))
-            param.data -= (
-                (self.lr / (1 - self.betas[0] ** self.t))
-                * self.m[i]
-                / (self.u[i] + self.eps)
-            )
+            self.m[i] = self.betas[0] * self.m[i] + (1 - self.betas[0]) * grad
+            self.u[i] = np.maximum(self.betas[1] * self.u[i], np.abs(grad))
+            param.data -= (self.lr / (1 - self.betas[0] ** self.t)) * self.m[i] / (self.u[i] + self.eps)

--- a/punytorch/ops.py
+++ b/punytorch/ops.py
@@ -1,6 +1,39 @@
 import numpy as np
 
 
+def _data(value):
+    return value.data if hasattr(value, "data") else value
+
+
+def _grad_data(value):
+    value = _data(value)
+    return np.asarray(value, dtype=np.float64)
+
+
+def _normalize_axis(axis, ndim):
+    if axis is None:
+        return None
+    if isinstance(axis, int):
+        axis = (axis,)
+    return tuple(ax if ax >= 0 else ndim + ax for ax in axis)
+
+
+def _unbroadcast(grad, shape):
+    grad = np.asarray(grad, dtype=np.float64)
+
+    if shape == ():
+        return np.asarray(grad.sum(), dtype=np.float64)
+
+    while grad.ndim > len(shape):
+        grad = grad.sum(axis=0)
+
+    for axis, size in enumerate(shape):
+        if size == 1 and grad.shape[axis] != 1:
+            grad = grad.sum(axis=axis, keepdims=True)
+
+    return grad.reshape(shape)
+
+
 class Function:
     def __init__(self, op, *args):
         self.op = op
@@ -20,6 +53,13 @@ class Function:
 
 
 class Operation:
+    """
+    Operation contract:
+    - forward receives Tensor inputs and returns NumPy-compatible data.
+    - backward receives the original Function context plus an upstream gradient
+      array and returns one gradient array, or None, per forward argument.
+    """
+
     def forward(self, *args):
         raise NotImplementedError
 
@@ -44,31 +84,8 @@ class Add(Operation):
         return grad for both x and y
         """
         x, y = context.args
-        from punytorch.tensor import Tensor
-
-        # For x gradient
-        grad_x_data = grad.data
-        # Sum over dimensions that were broadcast
-        ndims_added = grad_x_data.ndim - x.data.ndim
-        for i in range(ndims_added):
-            grad_x_data = np.sum(grad_x_data, axis=0)
-        # Sum over dimensions that were broadcast from size 1
-        for i, (dim, grad_dim) in enumerate(zip(x.data.shape, grad_x_data.shape)):
-            if dim == 1 and grad_dim > 1:
-                grad_x_data = np.sum(grad_x_data, axis=i, keepdims=True)
-
-        # For y gradient
-        grad_y_data = grad.data
-        # Sum over dimensions that were broadcast
-        ndims_added = grad_y_data.ndim - y.data.ndim
-        for i in range(ndims_added):
-            grad_y_data = np.sum(grad_y_data, axis=0)
-        # Sum over dimensions that were broadcast from size 1
-        for i, (dim, grad_dim) in enumerate(zip(y.data.shape, grad_y_data.shape)):
-            if dim == 1 and grad_dim > 1:
-                grad_y_data = np.sum(grad_y_data, axis=i, keepdims=True)
-
-        return Tensor(grad_x_data), Tensor(grad_y_data)
+        grad_data = _grad_data(grad)
+        return _unbroadcast(grad_data, x.data.shape), _unbroadcast(grad_data, y.data.shape)
 
 
 class Sub(Operation):
@@ -88,7 +105,9 @@ class Sub(Operation):
         return [1] for x
         return [-1] for y
         """
-        return grad, -grad
+        x, y = context.args
+        grad_data = _grad_data(grad)
+        return _unbroadcast(grad_data, x.data.shape), _unbroadcast(-grad_data, y.data.shape)
 
 
 class Mul(Operation):
@@ -109,7 +128,11 @@ class Mul(Operation):
         return (x.data * grad.data) for y
         """
         x, y = context.args
-        return y * grad, x * grad
+        grad_data = _grad_data(grad)
+        return (
+            _unbroadcast(grad_data * y.data, x.data.shape),
+            _unbroadcast(grad_data * x.data, y.data.shape),
+        )
 
 
 class TrueDiv(Operation):
@@ -130,9 +153,11 @@ class TrueDiv(Operation):
         return (-grad.data * x.data / (y.data ** 2)) for y
         """
         x, y = context.args
-        grad_x = grad / y
-        grad_y = -grad * x / (y * y)
-        return grad_x, grad_y
+        grad_data = _grad_data(grad)
+        return (
+            _unbroadcast(grad_data / y.data, x.data.shape),
+            _unbroadcast(-grad_data * x.data / (y.data**2), y.data.shape),
+        )
 
 
 class Mod(Operation):
@@ -162,7 +187,8 @@ class Mod(Operation):
         return an array of zerose like y.data for y
         """
         x, y = context.args
-        return grad, 0
+        grad_data = _grad_data(grad)
+        return _unbroadcast(grad_data, x.data.shape), np.zeros_like(y.data, dtype=np.float64)
 
 
 class Pow(Operation):
@@ -182,12 +208,12 @@ class Pow(Operation):
         return grad * (y * x ** (y - 1)) for x
         return grad * (x**y * np.log(x.data)) for y
         """
-        from punytorch.tensor import Tensor
-
         x, y = context.args
-        grad_x = grad * (y * x ** (y - 1))
-        grad_y = grad * (x**y * Tensor(np.log(x.data)))
-        return grad_x, grad_y
+        grad_data = _grad_data(grad)
+        result = x.data**y.data
+        grad_x = grad_data * y.data * (x.data ** (y.data - 1))
+        grad_y = grad_data * result * np.log(x.data)
+        return _unbroadcast(grad_x, x.data.shape), _unbroadcast(grad_y, y.data.shape)
 
 
 class MatMul(Operation):
@@ -206,7 +232,10 @@ class MatMul(Operation):
         d(Z)/dY = X.T @ grad
         """
         x, y = context.args
-        return grad @ y.T, x.T @ grad
+        grad_data = _grad_data(grad)
+        grad_x = grad_data @ np.swapaxes(y.data, -1, -2)
+        grad_y = np.swapaxes(x.data, -1, -2) @ grad_data
+        return _unbroadcast(grad_x, x.data.shape), _unbroadcast(grad_y, y.data.shape)
 
 
 class Tanh(Operation):
@@ -215,7 +244,7 @@ class Tanh(Operation):
         """
         z = tanh(x)
         """
-        return np.tanh(x)
+        return np.tanh(x.data)
 
     @staticmethod
     def backward(context, grad):
@@ -224,12 +253,10 @@ class Tanh(Operation):
 
         return (1 - tanh(x)^2) * grad
         """
-        from punytorch.tensor import Tensor
-
         x = context.args[0].data
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
+        grad_data = _grad_data(grad)
         grad_tanh = 1 - np.tanh(x) ** 2
-        return (Tensor(grad_tanh * grad_data),)
+        return (grad_tanh * grad_data,)
 
 
 class Transpose(Operation):
@@ -238,11 +265,11 @@ class Transpose(Operation):
     """
 
     @staticmethod
-    def forward(x):
+    def forward(x, axes=None):
         """
         z = x.T (transpose of x)
         """
-        return np.transpose(x.data)
+        return np.transpose(x.data, axes=axes)
 
     @staticmethod
     def backward(context, grad):
@@ -250,11 +277,12 @@ class Transpose(Operation):
         If Z = X.T, then d(Z)/dX = grad.T
         The gradient simply needs to be transposed back.
         """
-        from punytorch.tensor import Tensor
-
-        # Transpose the gradient back
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
-        return (Tensor(np.transpose(grad_data)),)
+        _, axes = context.args
+        grad_data = _grad_data(grad)
+        if axes is None:
+            return np.transpose(grad_data), None
+        inverse_axes = np.argsort(axes)
+        return np.transpose(grad_data, axes=inverse_axes), None
 
 
 class Reshape(Operation):
@@ -288,11 +316,9 @@ class Reshape(Operation):
         Returns:
             tuple: (Gradient reshaped to original shape, None for shape parameter)
         """
-        from punytorch.tensor import Tensor
-
         x, _ = context.args
-        grad_data = grad.data if hasattr(grad, "data") else grad
-        return Tensor(grad_data.reshape(x.shape)), None
+        grad_data = _grad_data(grad)
+        return grad_data.reshape(x.shape), None
 
 
 class Sum(Operation):
@@ -327,28 +353,19 @@ class Sum(Operation):
         Returns:
             tuple: (Gradient distributed to original shape, None for axis parameter)
         """
-        from punytorch.tensor import Tensor
-
         x, axis, keepdims = context.args
-        grad_data = grad.data if hasattr(grad, "data") else grad
+        grad_data = _grad_data(grad)
+        normalized_axis = _normalize_axis(axis, x.data.ndim)
 
         # Reshape gradient to match original tensor dimensions if keepdims=False
-        if axis is not None and not keepdims:
-            # Add back the reduced dimensions
-            if isinstance(axis, int):
-                axis = (axis,)
-            elif axis is None:
-                axis = tuple(range(x.data.ndim))
-            else:
-                axis = tuple(axis)
-
+        if normalized_axis is not None and not keepdims:
             # Expand dimensions that were reduced
-            for ax in sorted(axis):
+            for ax in sorted(normalized_axis):
                 grad_data = np.expand_dims(grad_data, axis=ax)
 
         # Broadcast gradient to original tensor shape
         grad_output = np.broadcast_to(grad_data, x.data.shape)
-        return Tensor(grad_output), None, None
+        return grad_output, None, None
 
 
 class Mean(Operation):
@@ -383,36 +400,27 @@ class Mean(Operation):
         Returns:
             tuple: (Gradient distributed to original shape, None for axis parameter)
         """
-        from punytorch.tensor import Tensor
-
         x, axis, keepdims = context.args
-        grad_data = grad.data if hasattr(grad, "data") else grad
+        grad_data = _grad_data(grad)
+        normalized_axis = _normalize_axis(axis, x.data.ndim)
 
         # Calculate the number of elements that contributed to the mean
-        if axis is None:
+        if normalized_axis is None:
             num_elements = x.data.size
+        elif len(normalized_axis) == 1:
+            num_elements = x.data.shape[normalized_axis[0]]
         else:
-            if isinstance(axis, int):
-                num_elements = x.data.shape[axis]
-            else:
-                num_elements = np.prod([x.data.shape[ax] for ax in axis])
+            num_elements = np.prod([x.data.shape[ax] for ax in normalized_axis])
 
         # Reshape gradient to match original tensor dimensions if keepdims=False
-        if axis is not None and not keepdims:
-            if isinstance(axis, int):
-                axis = (axis,)
-            elif axis is None:
-                axis = tuple(range(x.data.ndim))
-            else:
-                axis = tuple(axis)
-
+        if normalized_axis is not None and not keepdims:
             # Expand dimensions that were reduced
-            for ax in sorted(axis):
+            for ax in sorted(normalized_axis):
                 grad_data = np.expand_dims(grad_data, axis=ax)
 
         # Broadcast gradient to original tensor shape and scale by 1/N
         grad_output = np.broadcast_to(grad_data, x.data.shape) / num_elements
-        return Tensor(grad_output), None, None
+        return grad_output, None, None
 
 
 class Max(Operation):
@@ -447,26 +455,18 @@ class Max(Operation):
         Returns:
             tuple: (Gradient distributed to max elements only, None for axis parameter)
         """
-        from punytorch.tensor import Tensor
-
         x, axis, keepdims = context.args
-        grad_data = grad.data if hasattr(grad, "data") else grad
+        grad_data = _grad_data(grad)
+        normalized_axis = _normalize_axis(axis, x.data.ndim)
 
         # Find the maximum values and create a mask
         max_vals = np.max(x.data, axis=axis, keepdims=True)
         max_mask = (x.data == max_vals).astype(np.float64)
 
         # Reshape gradient to match original tensor dimensions if keepdims=False
-        if axis is not None and not keepdims:
-            if isinstance(axis, int):
-                axis = (axis,)
-            elif axis is None:
-                axis = tuple(range(x.data.ndim))
-            else:
-                axis = tuple(axis)
-
+        if normalized_axis is not None and not keepdims:
             # Expand dimensions that were reduced
-            for ax in sorted(axis):
+            for ax in sorted(normalized_axis):
                 grad_data = np.expand_dims(grad_data, axis=ax)
 
         # Broadcast gradient and apply mask (only max elements get gradient)
@@ -479,4 +479,4 @@ class Max(Operation):
         )  # Avoid division by zero
 
         grad_output = grad_broadcast * max_mask / num_max_elements
-        return Tensor(grad_output), None, None
+        return grad_output, None, None

--- a/punytorch/ops.py
+++ b/punytorch/ops.py
@@ -1,15 +1,6 @@
 import numpy as np
 
 
-def _data(value):
-    return value.data if hasattr(value, "data") else value
-
-
-def _grad_data(value):
-    value = _data(value)
-    return np.asarray(value, dtype=np.float64)
-
-
 def _normalize_axis(axis, ndim):
     if axis is None:
         return None
@@ -55,7 +46,7 @@ class Function:
 class Operation:
     """
     Operation contract:
-    - forward receives Tensor inputs and returns NumPy-compatible data.
+    - forward receives NumPy inputs and returns NumPy-compatible data.
     - backward receives the original Function context plus an upstream gradient
       array and returns one gradient array, or None, per forward argument.
     """
@@ -73,7 +64,7 @@ class Add(Operation):
         """
         z = x + y
         """
-        return x.data + y.data
+        return x + y
 
     @staticmethod
     def backward(context, grad):
@@ -84,7 +75,7 @@ class Add(Operation):
         return grad for both x and y
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return _unbroadcast(grad_data, x.data.shape), _unbroadcast(grad_data, y.data.shape)
 
 
@@ -94,7 +85,7 @@ class Sub(Operation):
         """
         z = x - y
         """
-        return x.data - y.data
+        return x - y
 
     @staticmethod
     def backward(context, grad):
@@ -106,7 +97,7 @@ class Sub(Operation):
         return [-1] for y
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return _unbroadcast(grad_data, x.data.shape), _unbroadcast(-grad_data, y.data.shape)
 
 
@@ -116,7 +107,7 @@ class Mul(Operation):
         """
         z = x * y
         """
-        return x.data * y.data
+        return x * y
 
     @staticmethod
     def backward(context, grad):
@@ -128,7 +119,7 @@ class Mul(Operation):
         return (x.data * grad.data) for y
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return (
             _unbroadcast(grad_data * y.data, x.data.shape),
             _unbroadcast(grad_data * x.data, y.data.shape),
@@ -141,7 +132,7 @@ class TrueDiv(Operation):
         """
         z = x / y
         """
-        return x.data / y.data
+        return x / y
 
     @staticmethod
     def backward(context, grad):
@@ -153,7 +144,7 @@ class TrueDiv(Operation):
         return (-grad.data * x.data / (y.data ** 2)) for y
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return (
             _unbroadcast(grad_data / y.data, x.data.shape),
             _unbroadcast(-grad_data * x.data / (y.data**2), y.data.shape),
@@ -175,7 +166,7 @@ class Mod(Operation):
         """
         z = x % y
         """
-        return x.data % y.data
+        return x % y
 
     @staticmethod
     def backward(context, grad):
@@ -187,7 +178,7 @@ class Mod(Operation):
         return an array of zerose like y.data for y
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return _unbroadcast(grad_data, x.data.shape), np.zeros_like(y.data, dtype=np.float64)
 
 
@@ -197,7 +188,7 @@ class Pow(Operation):
         """
         z = x ^ y
         """
-        return x.data**y.data
+        return x**y
 
     @staticmethod
     def backward(context, grad):
@@ -209,7 +200,7 @@ class Pow(Operation):
         return grad * (x**y * np.log(x.data)) for y
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         result = x.data**y.data
         grad_x = grad_data * y.data * (x.data ** (y.data - 1))
         grad_y = grad_data * result * np.log(x.data)
@@ -222,7 +213,7 @@ class MatMul(Operation):
         """
         z = x @ y
         """
-        return x.data @ y.data
+        return x @ y
 
     @staticmethod
     def backward(context, grad):
@@ -232,7 +223,7 @@ class MatMul(Operation):
         d(Z)/dY = X.T @ grad
         """
         x, y = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         grad_x = grad_data @ np.swapaxes(y.data, -1, -2)
         grad_y = np.swapaxes(x.data, -1, -2) @ grad_data
         return _unbroadcast(grad_x, x.data.shape), _unbroadcast(grad_y, y.data.shape)
@@ -244,7 +235,7 @@ class Tanh(Operation):
         """
         z = tanh(x)
         """
-        return np.tanh(x.data)
+        return np.tanh(x)
 
     @staticmethod
     def backward(context, grad):
@@ -254,7 +245,7 @@ class Tanh(Operation):
         return (1 - tanh(x)^2) * grad
         """
         x = context.args[0].data
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         grad_tanh = 1 - np.tanh(x) ** 2
         return (grad_tanh * grad_data,)
 
@@ -269,7 +260,7 @@ class Transpose(Operation):
         """
         z = x.T (transpose of x)
         """
-        return np.transpose(x.data, axes=axes)
+        return np.transpose(x, axes=axes)
 
     @staticmethod
     def backward(context, grad):
@@ -278,7 +269,7 @@ class Transpose(Operation):
         The gradient simply needs to be transposed back.
         """
         _, axes = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         if axes is None:
             return np.transpose(grad_data), None
         inverse_axes = np.argsort(axes)
@@ -302,7 +293,7 @@ class Reshape(Operation):
         Returns:
             numpy.ndarray: Reshaped tensor data
         """
-        return x.data.reshape(tuple(shape))
+        return x.reshape(tuple(shape))
 
     @staticmethod
     def backward(context, grad):
@@ -317,7 +308,7 @@ class Reshape(Operation):
             tuple: (Gradient reshaped to original shape, None for shape parameter)
         """
         x, _ = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         return grad_data.reshape(x.shape), None
 
 
@@ -339,7 +330,7 @@ class Sum(Operation):
         Returns:
             numpy.ndarray: Sum result
         """
-        return np.sum(x.data, axis=axis, keepdims=keepdims)
+        return np.sum(x, axis=axis, keepdims=keepdims)
 
     @staticmethod
     def backward(context, grad):
@@ -354,7 +345,7 @@ class Sum(Operation):
             tuple: (Gradient distributed to original shape, None for axis parameter)
         """
         x, axis, keepdims = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         normalized_axis = _normalize_axis(axis, x.data.ndim)
 
         # Reshape gradient to match original tensor dimensions if keepdims=False
@@ -386,7 +377,7 @@ class Mean(Operation):
         Returns:
             numpy.ndarray: Mean result
         """
-        return np.mean(x.data, axis=axis, keepdims=keepdims)
+        return np.mean(x, axis=axis, keepdims=keepdims)
 
     @staticmethod
     def backward(context, grad):
@@ -401,7 +392,7 @@ class Mean(Operation):
             tuple: (Gradient distributed to original shape, None for axis parameter)
         """
         x, axis, keepdims = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         normalized_axis = _normalize_axis(axis, x.data.ndim)
 
         # Calculate the number of elements that contributed to the mean
@@ -441,7 +432,7 @@ class Max(Operation):
         Returns:
             numpy.ndarray: Max result
         """
-        return np.max(x.data, axis=axis, keepdims=keepdims)
+        return np.max(x, axis=axis, keepdims=keepdims)
 
     @staticmethod
     def backward(context, grad):
@@ -456,7 +447,7 @@ class Max(Operation):
             tuple: (Gradient distributed to max elements only, None for axis parameter)
         """
         x, axis, keepdims = context.args
-        grad_data = _grad_data(grad)
+        grad_data = np.asarray(grad, dtype=np.float64)
         normalized_axis = _normalize_axis(axis, x.data.ndim)
 
         # Find the maximum values and create a mask
@@ -474,9 +465,7 @@ class Max(Operation):
 
         # Handle case where multiple elements achieve the maximum (split gradient)
         num_max_elements = np.sum(max_mask, axis=axis, keepdims=True)
-        num_max_elements = np.where(
-            num_max_elements == 0, 1, num_max_elements
-        )  # Avoid division by zero
+        num_max_elements = np.where(num_max_elements == 0, 1, num_max_elements)  # Avoid division by zero
 
         grad_output = grad_broadcast * max_mask / num_max_elements
         return grad_output, None, None

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -33,27 +33,19 @@ class Tensor:
         self.requires_grad = requires_grad
         # if requires_grad is True, then we need to initialize the gradient to zeros
         # and make sure that they're floats, since backprop uses floats
-        self.grad = (
-            np.zeros_like(self.data, dtype=np.float64) if requires_grad else None
-        )
+        self.grad = np.zeros_like(self.data, dtype=np.float64) if requires_grad else None
         self.dtype = self.data.dtype
         self.context = None
 
     @staticmethod
     def _should_track(*values):
-        return Tensor._compute_grad and any(
-            isinstance(value, Tensor) and value.requires_grad for value in values
-        )
-
-    @staticmethod
-    def _grad_data(grad):
-        if isinstance(grad, Tensor):
-            grad = grad.data
-        return np.asarray(grad, dtype=np.float64)
+        return Tensor._compute_grad and any(isinstance(value, Tensor) and value.requires_grad for value in values)
 
     @staticmethod
     def _match_grad_shape(grad, shape):
-        grad = Tensor._grad_data(grad)
+        if isinstance(grad, Tensor):
+            grad = grad.data
+        grad = np.asarray(grad, dtype=np.float64)
         if grad.shape == shape:
             return grad
         if shape == ():
@@ -81,7 +73,7 @@ class Tensor:
             class GetItem:
                 @staticmethod
                 def forward(x, index):
-                    return x.data[index]
+                    return x[index]
 
                 @staticmethod
                 def backward(context, grad):
@@ -89,7 +81,7 @@ class Tensor:
                     # Create a gradient tensor of the same shape as the original
                     grad_input = np.zeros_like(x.data, dtype=np.float64)
                     # Place the gradient at the indexed location
-                    np.add.at(grad_input, index, Tensor._grad_data(grad))
+                    np.add.at(grad_input, index, np.asarray(grad, dtype=np.float64))
                     return grad_input, None
 
             result.context = Function(GetItem, self, index_data)
@@ -101,7 +93,7 @@ class Tensor:
         from punytorch.ops import Transpose, Function
 
         track = Tensor._should_track(self)
-        result = Tensor(Transpose.forward(self), requires_grad=track)
+        result = Tensor(Transpose.forward(self.data), requires_grad=track)
         if track:
             result.context = Function(Transpose, self, None)
         return result
@@ -123,7 +115,7 @@ class Tensor:
         from punytorch.ops import Transpose
 
         track = Tensor._should_track(self)
-        result = Tensor(Transpose.forward(self, axes), requires_grad=track)
+        result = Tensor(Transpose.forward(self.data, axes), requires_grad=track)
         if track:
             result.context = Function(Transpose, self, axes)
         return result
@@ -132,9 +124,7 @@ class Tensor:
         return self.data.tolist()
 
     def item(self):
-        assert np.prod(self.data.shape) == 1, (
-            "Only one element tensors can be converted to Python scalars"
-        )
+        assert np.prod(self.data.shape) == 1, "Only one element tensors can be converted to Python scalars"
         return self.data.item()
 
     @staticmethod
@@ -190,11 +180,7 @@ class Tensor:
             if tensor.context is not None:
                 grads = tensor.context.op.backward(tensor.context, grad_data)
                 for arg, grad_arg in zip(tensor.context.args, grads):
-                    if (
-                        isinstance(arg, Tensor)
-                        and arg.requires_grad
-                        and grad_arg is not None
-                    ):
+                    if isinstance(arg, Tensor) and arg.requires_grad and grad_arg is not None:
                         stack.append((arg, grad_arg))
 
     @staticmethod
@@ -252,7 +238,7 @@ class Tensor:
         shape = tuple(curr // target if s == -1 else s for s in shape)
 
         track = Tensor._should_track(self)
-        result = Tensor(Reshape.forward(self, shape), requires_grad=track)
+        result = Tensor(Reshape.forward(self.data, shape), requires_grad=track)
         if track:
             result.context = Function(Reshape, self, shape)
         return result
@@ -273,7 +259,7 @@ class Tensor:
             Tensor: Sum result with proper gradient tracking.
         """
         track = Tensor._should_track(self)
-        result = Tensor(Sum.forward(self, axis, keepdims), requires_grad=track)
+        result = Tensor(Sum.forward(self.data, axis, keepdims), requires_grad=track)
         if track:
             result.context = Function(Sum, self, axis, keepdims)
         return result
@@ -290,7 +276,7 @@ class Tensor:
             Tensor: Mean result with proper gradient tracking.
         """
         track = Tensor._should_track(self)
-        result = Tensor(Mean.forward(self, axis, keepdims), requires_grad=track)
+        result = Tensor(Mean.forward(self.data, axis, keepdims), requires_grad=track)
         if track:
             result.context = Function(Mean, self, axis, keepdims)
         return result
@@ -307,7 +293,7 @@ class Tensor:
             Tensor: Max result with proper gradient tracking.
         """
         track = Tensor._should_track(self)
-        result = Tensor(Max.forward(self, axis, keepdims), requires_grad=track)
+        result = Tensor(Max.forward(self.data, axis, keepdims), requires_grad=track)
         if track:
             result.context = Function(Max, self, axis, keepdims)
         return result
@@ -319,7 +305,7 @@ class Tensor:
     def __add__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(Add.forward(self, other), requires_grad=track)
+        result = Tensor(Add.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(Add, self, other)
         return result
@@ -327,7 +313,7 @@ class Tensor:
     def __sub__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(Sub.forward(self, other), requires_grad=track)
+        result = Tensor(Sub.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(Sub, self, other)
         return result
@@ -335,7 +321,7 @@ class Tensor:
     def __mul__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(Mul.forward(self, other), requires_grad=track)
+        result = Tensor(Mul.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(Mul, self, other)
         return result
@@ -343,7 +329,7 @@ class Tensor:
     def __truediv__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(TrueDiv.forward(self, other), requires_grad=track)
+        result = Tensor(TrueDiv.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(TrueDiv, self, other)
         return result
@@ -351,7 +337,7 @@ class Tensor:
     def __mod__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(Mod.forward(self, other), requires_grad=track)
+        result = Tensor(Mod.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(Mod, self, other)
         return result
@@ -359,7 +345,7 @@ class Tensor:
     def __pow__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(Pow.forward(self, other), requires_grad=track)
+        result = Tensor(Pow.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(Pow, self, other)
         return result
@@ -367,7 +353,7 @@ class Tensor:
     def __matmul__(self, other):
         other = Tensor.ensure_tensor(other)
         track = Tensor._should_track(self, other)
-        result = Tensor(MatMul.forward(self, other), requires_grad=track)
+        result = Tensor(MatMul.forward(self.data, other.data), requires_grad=track)
         if track:
             result.context = Function(MatMul, self, other)
         return result
@@ -409,7 +395,7 @@ class Tensor:
 
     def tanh(self):
         track = Tensor._should_track(self)
-        result = Tensor(Tanh.forward(self), requires_grad=track)
+        result = Tensor(Tanh.forward(self.data), requires_grad=track)
         if track:
             result.context = Function(Tanh, self)
         return result
@@ -425,21 +411,21 @@ class Tensor:
 
     def relu(self):
         track = Tensor._should_track(self)
-        result = Tensor(ReLU.forward(self), requires_grad=track)
+        result = Tensor(ReLU.forward(self.data), requires_grad=track)
         if track:
             result.context = Function(ReLU, self)
         return result
 
     def sigmoid(self):
         track = Tensor._should_track(self)
-        result = Tensor(Sigmoid.forward(self), requires_grad=track)
+        result = Tensor(Sigmoid.forward(self.data), requires_grad=track)
         if track:
             result.context = Function(Sigmoid, self)
         return result
 
     def softmax(self, dim=None):
         track = Tensor._should_track(self)
-        result = Tensor(Softmax.forward(self, dim=dim), requires_grad=track)
+        result = Tensor(Softmax.forward(self.data, dim=dim), requires_grad=track)
         if track:
             result.context = Function(Softmax, self, dim)
         return result
@@ -459,7 +445,7 @@ class Tensor:
 
         targets = Tensor.ensure_tensor(targets)
         track = Tensor._should_track(self)
-        result = Tensor(CrossEntropyLoss.forward(self, targets), requires_grad=track)
+        result = Tensor(CrossEntropyLoss.forward(self.data, targets.data), requires_grad=track)
         if track:
             result.context = Function(CrossEntropyLoss, self, targets)
         return result
@@ -482,9 +468,7 @@ class Tensor:
 
     @staticmethod
     def multinomial(input, num_samples):
-        return Tensor(
-            np.random.choice(range(input.shape[1]), size=num_samples, p=input.data[0])
-        )
+        return Tensor(np.random.choice(range(input.shape[1]), size=num_samples, p=input.data[0]))
 
     @staticmethod
     def cat(tensors, dim=0):
@@ -512,6 +496,4 @@ class Tensor:
         if device == "cpu":
             return self  # Since NumPy arrays are already on the CPU, just return self.
         else:
-            raise NotImplementedError(
-                "Only 'cpu' device is supported for the Tensor class."
-            )
+            raise NotImplementedError("Only 'cpu' device is supported for the Tensor class.")

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -81,7 +81,11 @@ class Tensor:
                     # Create a gradient tensor of the same shape as the original
                     grad_input = np.zeros_like(x.data, dtype=np.float64)
                     # Place the gradient at the indexed location
-                    np.add.at(grad_input, index, np.asarray(grad, dtype=np.float64))
+                    grad_data = np.asarray(grad, dtype=np.float64)
+                    try:
+                        np.add.at(grad_input, index, grad_data)
+                    except TypeError:
+                        grad_input[index] += grad_data
                     return grad_input, None
 
             result.context = Function(GetItem, self, index_data)

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -21,8 +21,12 @@ from punytorch.ops import (
 
 
 class Tensor:
+    _compute_grad = True
+
     def __init__(self, data, requires_grad=False):
-        if isinstance(data, np.ndarray):
+        if isinstance(data, Tensor):
+            self.data = data.data.copy()
+        elif isinstance(data, np.ndarray):
             self.data = data
         else:
             self.data = np.array(data)
@@ -35,6 +39,29 @@ class Tensor:
         self.dtype = self.data.dtype
         self.context = None
 
+    @staticmethod
+    def _should_track(*values):
+        return Tensor._compute_grad and any(
+            isinstance(value, Tensor) and value.requires_grad for value in values
+        )
+
+    @staticmethod
+    def _grad_data(grad):
+        if isinstance(grad, Tensor):
+            grad = grad.data
+        return np.asarray(grad, dtype=np.float64)
+
+    @staticmethod
+    def _match_grad_shape(grad, shape):
+        grad = Tensor._grad_data(grad)
+        if grad.shape == shape:
+            return grad
+        if shape == ():
+            return np.asarray(grad.sum(), dtype=np.float64)
+        if grad.shape == ():
+            return np.broadcast_to(grad, shape).astype(np.float64)
+        return grad.reshape(shape)
+
     @property
     def shape(self):
         return self.data.shape
@@ -43,14 +70,14 @@ class Tensor:
         return self.data.shape[0]
 
     def __getitem__(self, index):
+        index_data = index.data if isinstance(index, Tensor) else index
         # Create a new tensor from the indexed data
-        result = Tensor(self.data[index], requires_grad=self.requires_grad)
+        track = Tensor._should_track(self)
+        result = Tensor(self.data[index_data], requires_grad=track)
 
         # If this tensor requires gradients, we need to set up the backward connection
-        if self.requires_grad:
+        if track:
             # We need to create a custom indexing operation that can propagate gradients
-            from punytorch.ops import Function
-
             class GetItem:
                 @staticmethod
                 def forward(x, index):
@@ -62,10 +89,10 @@ class Tensor:
                     # Create a gradient tensor of the same shape as the original
                     grad_input = np.zeros_like(x.data, dtype=np.float64)
                     # Place the gradient at the indexed location
-                    grad_input[index] = grad.data if hasattr(grad, "data") else grad
-                    return Tensor(grad_input), None
+                    np.add.at(grad_input, index, Tensor._grad_data(grad))
+                    return grad_input, None
 
-            result.context = Function(GetItem, self, index)
+            result.context = Function(GetItem, self, index_data)
 
         return result
 
@@ -73,9 +100,10 @@ class Tensor:
     def T(self):
         from punytorch.ops import Transpose, Function
 
-        result = Tensor(Transpose.forward(self), requires_grad=self.requires_grad)
-        if self.requires_grad:
-            result.context = Function(Transpose, self)
+        track = Tensor._should_track(self)
+        result = Tensor(Transpose.forward(self), requires_grad=track)
+        if track:
+            result.context = Function(Transpose, self, None)
         return result
 
     def transpose(self, dim0, dim1):
@@ -91,8 +119,14 @@ class Tensor:
         """
         axes = list(range(self.data.ndim))
         axes[dim0], axes[dim1] = axes[dim1], axes[dim0]
-        data = self.data.transpose(axes)
-        return Tensor(data, requires_grad=self.requires_grad)
+        axes = tuple(axes)
+        from punytorch.ops import Transpose
+
+        track = Tensor._should_track(self)
+        result = Tensor(Transpose.forward(self, axes), requires_grad=track)
+        if track:
+            result.context = Function(Transpose, self, axes)
+        return result
 
     def tolist(self):
         return self.data.tolist()
@@ -141,22 +175,26 @@ class Tensor:
 
     def backward(self, grad=None):
         if grad is None:
-            grad = Tensor(np.ones_like(self.data))
+            grad = np.ones_like(self.data, dtype=np.float64)
+        else:
+            grad = Tensor._match_grad_shape(grad, self.data.shape)
 
         stack = [(self, grad)]
         while stack:
             tensor, grad = stack.pop()
+            grad_data = Tensor._match_grad_shape(grad, tensor.data.shape)
+            if tensor.requires_grad:
+                if tensor.grad is None:
+                    tensor.grad = np.zeros_like(tensor.data, dtype=np.float64)
+                tensor.grad += grad_data
             if tensor.context is not None:
-                grads = tensor.context.op.backward(tensor.context, grad)
+                grads = tensor.context.op.backward(tensor.context, grad_data)
                 for arg, grad_arg in zip(tensor.context.args, grads):
                     if (
                         isinstance(arg, Tensor)
                         and arg.requires_grad
                         and grad_arg is not None
                     ):
-                        if arg.grad is None:
-                            arg.grad = np.zeros_like(arg.data)
-                        arg.grad += grad_arg.data  # Ensure grad_arg is a numpy array
                         stack.append((arg, grad_arg))
 
     @staticmethod
@@ -183,10 +221,11 @@ class Tensor:
                 return wrapper
 
             def __enter__(self):
+                self.prev = Tensor._compute_grad
                 Tensor._compute_grad = False
 
             def __exit__(self, exc_type, exc_value, traceback):
-                Tensor._compute_grad = True
+                Tensor._compute_grad = self.prev
 
         return NoGradContext()
 
@@ -212,8 +251,9 @@ class Tensor:
         target = self.prod((s for s in shape if s != -1))
         shape = tuple(curr // target if s == -1 else s for s in shape)
 
-        result = Tensor(Reshape.forward(self, shape), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(Reshape.forward(self, shape), requires_grad=track)
+        if track:
             result.context = Function(Reshape, self, shape)
         return result
 
@@ -232,10 +272,9 @@ class Tensor:
         Returns:
             Tensor: Sum result with proper gradient tracking.
         """
-        result = Tensor(
-            Sum.forward(self, axis, keepdims), requires_grad=self.requires_grad
-        )
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(Sum.forward(self, axis, keepdims), requires_grad=track)
+        if track:
             result.context = Function(Sum, self, axis, keepdims)
         return result
 
@@ -250,10 +289,9 @@ class Tensor:
         Returns:
             Tensor: Mean result with proper gradient tracking.
         """
-        result = Tensor(
-            Mean.forward(self, axis, keepdims), requires_grad=self.requires_grad
-        )
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(Mean.forward(self, axis, keepdims), requires_grad=track)
+        if track:
             result.context = Function(Mean, self, axis, keepdims)
         return result
 
@@ -268,10 +306,9 @@ class Tensor:
         Returns:
             Tensor: Max result with proper gradient tracking.
         """
-        result = Tensor(
-            Max.forward(self, axis, keepdims), requires_grad=self.requires_grad
-        )
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(Max.forward(self, axis, keepdims), requires_grad=track)
+        if track:
             result.context = Function(Max, self, axis, keepdims)
         return result
 
@@ -281,58 +318,58 @@ class Tensor:
 
     def __add__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Add.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(Add.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(Add, self, other)
-            result.requires_grad = True
         return result
 
     def __sub__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Sub.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(Sub.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(Sub, self, other)
-            result.requires_grad = True
         return result
 
     def __mul__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Mul.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(Mul.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(Mul, self, other)
-            result.requires_grad = True
         return result
 
     def __truediv__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(TrueDiv.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(TrueDiv.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(TrueDiv, self, other)
-            result.requires_grad = True
         return result
 
     def __mod__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Mod.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(Mod.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(Mod, self, other)
-            result.requires_grad = True
         return result
 
     def __pow__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Pow.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(Pow.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(Pow, self, other)
-            result.requires_grad = True
         return result
 
     def __matmul__(self, other):
         other = Tensor.ensure_tensor(other)
-        result = Tensor(MatMul.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        track = Tensor._should_track(self, other)
+        result = Tensor(MatMul.forward(self, other), requires_grad=track)
+        if track:
             result.context = Function(MatMul, self, other)
-            result.requires_grad = True
         return result
 
     # Right-hand operators for scalar operations
@@ -350,6 +387,10 @@ class Tensor:
         other = Tensor.ensure_tensor(other)
         return other.__truediv__(self)
 
+    def __rpow__(self, other) -> "Tensor":
+        other = Tensor.ensure_tensor(other)
+        return other.__pow__(self)
+
     """
     UNARY OPS
     """
@@ -358,7 +399,7 @@ class Tensor:
         return Tensor(np.abs(self.data))
 
     def __neg__(self) -> "Tensor":
-        return Tensor(-self.data)
+        return self * -1
 
     def __invert__(self) -> "Tensor":
         return Tensor(~self.data)
@@ -367,8 +408,9 @@ class Tensor:
         return f"tensor({self.data})"
 
     def tanh(self):
-        result = Tensor(Tanh.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(Tanh.forward(self), requires_grad=track)
+        if track:
             result.context = Function(Tanh, self)
         return result
 
@@ -382,21 +424,24 @@ class Tensor:
         self.grad = np.zeros_like(self.data, dtype=float)
 
     def relu(self):
-        result = Tensor(ReLU.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(ReLU.forward(self), requires_grad=track)
+        if track:
             result.context = Function(ReLU, self)
         return result
 
     def sigmoid(self):
-        result = Tensor(Sigmoid.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(Sigmoid.forward(self), requires_grad=track)
+        if track:
             result.context = Function(Sigmoid, self)
         return result
 
-    def softmax(self):
-        result = Tensor(Softmax.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
-            result.context = Function(Softmax, self)
+    def softmax(self, dim=None):
+        track = Tensor._should_track(self)
+        result = Tensor(Softmax.forward(self, dim=dim), requires_grad=track)
+        if track:
+            result.context = Function(Softmax, self, dim)
         return result
 
     def cross_entropy(self, targets):
@@ -413,8 +458,9 @@ class Tensor:
         from punytorch.ops import Function
 
         targets = Tensor.ensure_tensor(targets)
-        result = Tensor(CrossEntropyLoss.forward(self, targets), requires_grad=True)
-        if self.requires_grad or targets.requires_grad:
+        track = Tensor._should_track(self)
+        result = Tensor(CrossEntropyLoss.forward(self, targets), requires_grad=track)
+        if track:
             result.context = Function(CrossEntropyLoss, self, targets)
         return result
 

--- a/tests/test_gradcheck.py
+++ b/tests/test_gradcheck.py
@@ -1,0 +1,203 @@
+import numpy as np
+import pytest
+
+from punytorch.tensor import Tensor
+
+
+EPS = 1e-6
+ATOL = 2e-5
+RTOL = 2e-5
+
+
+def _as_array(data):
+    return np.array(data, dtype=np.float64, copy=True)
+
+
+def _scalar_value(output, upstream):
+    data = np.asarray(output.data, dtype=np.float64)
+    if upstream is None:
+        assert data.size == 1
+        return float(data.reshape(-1)[0])
+    return float(np.sum(data * upstream))
+
+
+def _make_tensors(arrays, wrt):
+    return [
+        Tensor(array.copy(), requires_grad=index in wrt)
+        for index, array in enumerate(arrays)
+    ]
+
+
+def _finite_difference(fn, arrays, arg_index, upstream):
+    expected = np.zeros_like(arrays[arg_index], dtype=np.float64)
+
+    for index in np.ndindex(expected.shape):
+        plus = [array.copy() for array in arrays]
+        minus = [array.copy() for array in arrays]
+        plus[arg_index][index] += EPS
+        minus[arg_index][index] -= EPS
+
+        plus_output = fn(*_make_tensors(plus, wrt=()))
+        minus_output = fn(*_make_tensors(minus, wrt=()))
+        expected[index] = (_scalar_value(plus_output, upstream) - _scalar_value(minus_output, upstream)) / (
+            2 * EPS
+        )
+
+    return expected
+
+
+def assert_gradcheck(fn, inputs, *, upstream=None, wrt=None):
+    arrays = [_as_array(data) for data in inputs]
+    if wrt is None:
+        wrt = tuple(range(len(arrays)))
+    if upstream is not None:
+        upstream = _as_array(upstream)
+
+    tensors = _make_tensors(arrays, wrt)
+    output = fn(*tensors)
+    output.backward(None if upstream is None else Tensor(upstream))
+
+    for arg_index in wrt:
+        expected = _finite_difference(fn, arrays, arg_index, upstream)
+        actual = tensors[arg_index].grad
+        assert actual is not None
+        np.testing.assert_allclose(actual, expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize(
+    ("fn", "inputs", "upstream"),
+    [
+        (
+            lambda x, y: x + y,
+            ([1.0, -2.0, 0.5], [-0.5, 3.0, 2.0]),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x - y,
+            ([1.0, -2.0, 0.5], [-0.5, 3.0, 2.0]),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x * y,
+            ([1.0, -2.0, 0.5], [-0.5, 3.0, 2.0]),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x / y,
+            ([1.0, -2.0, 0.5], [2.0, -4.0, 0.75]),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x**y,
+            ([0.8, 1.2, 1.7], [1.5, 2.0, 0.5]),
+            [0.25, -1.0, 2.0],
+        ),
+    ],
+)
+def test_elementwise_vector_gradcheck(fn, inputs, upstream):
+    assert_gradcheck(fn, inputs, upstream=upstream)
+
+
+@pytest.mark.parametrize(
+    ("fn", "inputs", "upstream"),
+    [
+        (
+            lambda x, y: x + y,
+            ([1.0, -2.0, 0.5], 0.75),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x - y,
+            ([1.0, -2.0, 0.5], 0.75),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x * y,
+            ([1.0, -2.0, 0.5], 0.75),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x / y,
+            ([1.0, -2.0, 0.5], 1.5),
+            [0.25, -1.0, 2.0],
+        ),
+        (
+            lambda x, y: x**y,
+            ([0.8, 1.2, 1.7], 1.5),
+            [0.25, -1.0, 2.0],
+        ),
+    ],
+)
+def test_elementwise_scalar_operand_gradcheck(fn, inputs, upstream):
+    assert_gradcheck(fn, inputs, upstream=upstream)
+
+
+def test_matmul_gradcheck():
+    assert_gradcheck(
+        lambda x, y: x @ y,
+        (
+            [[1.0, -2.0, 0.5], [0.25, 1.5, -1.0]],
+            [[0.5, -1.0], [2.0, 0.75], [-1.5, 1.25]],
+        ),
+        upstream=[[0.5, -1.0], [1.5, 0.25]],
+    )
+
+
+@pytest.mark.parametrize(
+    ("fn", "inputs"),
+    [
+        (lambda x: x.sum(), ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],)),
+        (lambda x: x.mean(), ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],)),
+    ],
+)
+def test_reduction_scalar_gradcheck(fn, inputs):
+    assert_gradcheck(fn, inputs)
+
+
+@pytest.mark.parametrize(
+    ("fn", "inputs", "upstream"),
+    [
+        (
+            lambda x: x.sum(axis=1),
+            ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],),
+            [0.5, -1.5],
+        ),
+        (
+            lambda x: x.mean(axis=0),
+            ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],),
+            [0.5, -1.5, 2.0],
+        ),
+    ],
+)
+def test_reduction_vector_gradcheck(fn, inputs, upstream):
+    assert_gradcheck(fn, inputs, upstream=upstream)
+
+
+def test_reshape_gradcheck():
+    assert_gradcheck(
+        lambda x: x.reshape(3, 2),
+        ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],),
+        upstream=[[0.5, -1.0], [1.5, 0.25], [-0.75, 2.0]],
+    )
+
+
+@pytest.mark.parametrize(
+    ("fn", "inputs", "upstream"),
+    [
+        (lambda x: x.relu(), ([-1.5, -0.2, 0.4, 2.0],), [0.5, -1.0, 1.5, 0.25]),
+        (lambda x: x.sigmoid(), ([-1.5, -0.2, 0.4, 2.0],), [0.5, -1.0, 1.5, 0.25]),
+    ],
+)
+def test_activation_gradcheck(fn, inputs, upstream):
+    assert_gradcheck(fn, inputs, upstream=upstream)
+
+
+def test_cross_entropy_2d_logits_gradcheck():
+    assert_gradcheck(
+        lambda logits, targets: logits.cross_entropy(targets),
+        (
+            [[1.2, -0.7, 0.3], [-0.4, 0.9, 1.5]],
+            [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        ),
+        wrt=(0,),
+    )

--- a/tests/test_gradcheck.py
+++ b/tests/test_gradcheck.py
@@ -3,7 +3,6 @@ import pytest
 
 from punytorch.tensor import Tensor
 
-
 EPS = 1e-6
 ATOL = 2e-5
 RTOL = 2e-5
@@ -22,10 +21,7 @@ def _scalar_value(output, upstream):
 
 
 def _make_tensors(arrays, wrt):
-    return [
-        Tensor(array.copy(), requires_grad=index in wrt)
-        for index, array in enumerate(arrays)
-    ]
+    return [Tensor(array.copy(), requires_grad=index in wrt) for index, array in enumerate(arrays)]
 
 
 def _finite_difference(fn, arrays, arg_index, upstream):
@@ -39,9 +35,7 @@ def _finite_difference(fn, arrays, arg_index, upstream):
 
         plus_output = fn(*_make_tensors(plus, wrt=()))
         minus_output = fn(*_make_tensors(minus, wrt=()))
-        expected[index] = (_scalar_value(plus_output, upstream) - _scalar_value(minus_output, upstream)) / (
-            2 * EPS
-        )
+        expected[index] = (_scalar_value(plus_output, upstream) - _scalar_value(minus_output, upstream)) / (2 * EPS)
 
     return expected
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -14,7 +14,7 @@ from punytorch.tensor import Tensor
 def test_MSELoss():
     y_true = Tensor([1.0, 2.0, 3.0])
     y_pred = Tensor([1.0, 2.0, 3.0], requires_grad=True)
-    assert np.isclose(MSELoss.forward(y_pred, y_true), 0.0)
+    assert np.isclose(MSELoss.forward(y_pred.data, y_true.data), 0.0)
 
     grad_pred, grad_true = MSELoss.backward(Function(MSELoss, y_pred, y_true), 1.0)
     assert np.allclose(grad_pred, np.array([0.0, 0.0, 0.0]))
@@ -54,7 +54,10 @@ def test_CrossEntropyLoss_supports_1d_logits():
 def test_BinaryCrossEntropyLoss():
     y_true = Tensor([1.0, 1.0, 1.0])
     y_pred = Tensor([0.9, 0.8, 0.9], requires_grad=True)
-    assert np.isclose(BinaryCrossEntropyLoss.forward(y_pred, y_true), 0.14462152754328741)
+    assert np.isclose(
+        BinaryCrossEntropyLoss.forward(y_pred.data, y_true.data),
+        0.14462152754328741,
+    )
 
     grad_pred, grad_true = BinaryCrossEntropyLoss.backward(
         Function(BinaryCrossEntropyLoss, y_pred, y_true),
@@ -68,7 +71,7 @@ def test_CategoricalCrossEntropyLoss():
     y_true = Tensor([1.0, 0.0, 0.0])
     y_pred = Tensor([0.7, 0.2, 0.1], requires_grad=True)
     assert np.isclose(
-        CategoricalCrossEntropyLoss.forward(y_pred, y_true),
+        CategoricalCrossEntropyLoss.forward(y_pred.data, y_true.data),
         0.35667494393873245,
     )
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -7,69 +7,74 @@ from punytorch.losses import (
     BinaryCrossEntropyLoss,
     CategoricalCrossEntropyLoss,
 )
+from punytorch.ops import Function
 from punytorch.tensor import Tensor
 
 
 def test_MSELoss():
     y_true = Tensor([1.0, 2.0, 3.0])
-    y_pred = Tensor([1.0, 2.0, 3.0])
-    assert np.isclose(MSELoss.forward(y_pred.data, y_true.data).data, Tensor(0.0).data)
-    assert np.allclose(
-        MSELoss.backward(y_pred.data, y_true.data).data, Tensor([0.0, 0.0, 0.0]).data
-    )
+    y_pred = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+    assert np.isclose(MSELoss.forward(y_pred, y_true), 0.0)
+
+    grad_pred, grad_true = MSELoss.backward(Function(MSELoss, y_pred, y_true), 1.0)
+    assert np.allclose(grad_pred, np.array([0.0, 0.0, 0.0]))
+    assert grad_true is None
 
 
 @pytest.mark.gpt
 @pytest.mark.mnist
 def test_CrossEntropyLoss():
-    # create and test both 1-dimensional and 2-dimensional tensors
-    y_true_1d = Tensor([1.0, 0.0, 0.0])
-    y_pred_1d = Tensor([0.7, 0.2, 0.1])
-    y_true_2d = Tensor([[1.0, 0.0, 0.0]])
-    y_pred_2d = Tensor([[0.7, 0.2, 0.1]])
+    targets = Tensor([[1.0, 0.0, 0.0]])
+    logits = Tensor([[2.0, 1.0, 0.1]], requires_grad=True)
 
-    # test of 1-dimensional tensor
-    assert np.isclose(
-        CrossEntropyLoss.forward(y_pred_1d.data, y_true_1d.data).data,
-        0.2559831829678749,
-    )
+    loss = logits.cross_entropy(targets)
+    assert np.isclose(loss.data, 0.41703001627783354)
+
+    loss.backward()
     assert np.allclose(
-        CrossEntropyLoss.backward(y_pred_1d.data, y_true_1d.data).data,
-        np.array([-0.17867886, 0.09380268, 0.08487618]),
+        logits.grad,
+        np.array([[-0.34099886, 0.24243297, 0.09856589]]),
     )
 
-    # test of 2-dimensional tensor
-    assert np.isclose(
-        CrossEntropyLoss.forward(y_pred_2d.data, y_true_2d.data).data,
-        0.7679495489036248,
-    )
+
+def test_CrossEntropyLoss_supports_1d_logits():
+    targets = Tensor([1.0, 0.0, 0.0])
+    logits = Tensor([2.0, 1.0, 0.1], requires_grad=True)
+
+    loss = logits.cross_entropy(targets)
+    assert np.isclose(loss.data, 0.41703001627783354)
+
+    loss.backward()
     assert np.allclose(
-        CrossEntropyLoss.backward(y_pred_2d.data, y_true_2d.data).data,
-        np.array([[-0.53603657, 0.28140804, 0.25462853]]),
+        logits.grad,
+        np.array([-0.34099886, 0.24243297, 0.09856589]),
     )
 
 
 def test_BinaryCrossEntropyLoss():
     y_true = Tensor([1.0, 1.0, 1.0])
-    y_pred = Tensor([0.9, 0.8, 0.9])
-    assert np.isclose(
-        BinaryCrossEntropyLoss.forward(y_pred.data, y_true.data).data,
-        0.14462152754328741,
+    y_pred = Tensor([0.9, 0.8, 0.9], requires_grad=True)
+    assert np.isclose(BinaryCrossEntropyLoss.forward(y_pred, y_true), 0.14462152754328741)
+
+    grad_pred, grad_true = BinaryCrossEntropyLoss.backward(
+        Function(BinaryCrossEntropyLoss, y_pred, y_true),
+        1.0,
     )
-    assert np.allclose(
-        BinaryCrossEntropyLoss.backward(y_pred.data, y_true.data),
-        np.array([-1.11111111, -1.25, -1.11111111]),
-    )
+    assert np.allclose(grad_pred, np.array([-0.37037037, -0.41666667, -0.37037037]))
+    assert grad_true is None
 
 
 def test_CategoricalCrossEntropyLoss():
     y_true = Tensor([1.0, 0.0, 0.0])
-    y_pred = Tensor([0.7, 0.2, 0.1])
+    y_pred = Tensor([0.7, 0.2, 0.1], requires_grad=True)
     assert np.isclose(
-        CategoricalCrossEntropyLoss.forward(y_pred.data, y_true.data).data,
+        CategoricalCrossEntropyLoss.forward(y_pred, y_true),
         0.35667494393873245,
     )
-    assert np.allclose(
-        CategoricalCrossEntropyLoss.backward(y_pred.data, y_true.data),
-        np.array([-1.42857143, 0.0, 0.0]),
+
+    grad_pred, grad_true = CategoricalCrossEntropyLoss.backward(
+        Function(CategoricalCrossEntropyLoss, y_pred, y_true),
+        1.0,
     )
+    assert np.allclose(grad_pred, np.array([-1.42857143, 0.0, 0.0]))
+    assert grad_true is None

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1,0 +1,116 @@
+import numpy as np
+import pytest
+
+from punytorch.nn.modules import Linear, Module, ModuleList, Parameter
+from punytorch.nn.optimizers import SGD, Adadelta, Adagrad, Adam, Adamax, RMSProp
+from punytorch.tensor import Tensor
+
+
+class NestedModel(Module):
+    def __init__(self):
+        self.first = Linear(2, 3)
+        self.layers = ModuleList([Linear(3, 2), Linear(2, 1, bias=False)])
+        self.scale = Parameter(np.array([1.0]))
+
+
+class SharedParameterModel(NestedModel):
+    def __init__(self):
+        super().__init__()
+        self.alias = self.first.weight
+
+
+def test_parameters_are_in_deterministic_traversal_order_without_duplicates():
+    model = SharedParameterModel()
+
+    assert model.parameters() == [
+        model.first.weight,
+        model.first.bias,
+        model.layers[0].weight,
+        model.layers[0].bias,
+        model.layers[1].weight,
+        model.scale,
+    ]
+
+
+def test_state_dict_round_trips_nested_module_list_dotted_keys():
+    source = NestedModel()
+    source.first.weight.data = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    source.first.bias.data = np.array([7.0, 8.0, 9.0])
+    source.layers[0].weight.data = np.array([[10.0, 11.0, 12.0], [13.0, 14.0, 15.0]])
+    source.layers[0].bias.data = np.array([16.0, 17.0])
+    source.layers[1].weight.data = np.array([[18.0, 19.0]])
+    source.scale.data = np.array([20.0])
+
+    state = source.state_dict()
+
+    assert list(state.keys()) == [
+        "first.weight",
+        "first.bias",
+        "layers.0.weight",
+        "layers.0.bias",
+        "layers.1.weight",
+        "scale",
+    ]
+
+    target = NestedModel()
+    target.load_state_dict(state)
+
+    for key, value in state.items():
+        np.testing.assert_allclose(target.state_dict()[key].data, value.data)
+
+    loaded = target.first.weight.data.copy()
+    state["first.weight"].data.fill(-1.0)
+    np.testing.assert_allclose(target.first.weight.data, loaded)
+
+
+def test_linear_without_bias_has_no_bias_parameter_and_forward_works():
+    layer = Linear(2, 1, bias=False)
+    layer.weight.data = np.array([[2.0, 3.0]])
+
+    output = layer(Tensor(np.array([[4.0, 5.0]])))
+
+    assert layer.bias is None
+    assert layer.parameters() == [layer.weight]
+    assert list(layer.state_dict().keys()) == ["weight"]
+    np.testing.assert_allclose(output.data, np.array([[23.0]]))
+
+
+@pytest.mark.parametrize(
+    "optimizer_factory",
+    [
+        lambda params: SGD(params, lr=0.1),
+        lambda params: Adam(params, lr=0.1),
+        lambda params: RMSProp(params, lr=0.1),
+        lambda params: Adagrad(params, lr=0.1),
+        lambda params: Adadelta(params),
+        lambda params: Adamax(params, lr=0.1),
+    ],
+)
+@pytest.mark.parametrize(
+    "grad",
+    [
+        np.array([0.25, -0.5]),
+        Tensor(np.array([0.25, -0.5])),
+    ],
+)
+def test_optimizers_accept_array_and_tensor_grads(optimizer_factory, grad):
+    param = Parameter(np.array([1.0, -2.0]))
+    param.grad = grad
+    optimizer = optimizer_factory([param])
+
+    before = param.data.copy()
+    optimizer.step()
+
+    assert np.all(np.isfinite(param.data))
+    assert not np.allclose(param.data, before)
+
+
+def test_zero_grad_handles_tensor_grad_and_materializes_array():
+    param = Parameter(np.array([1.0, -2.0]))
+    param.grad = Tensor(np.array([0.25, -0.5]))
+    optimizer = SGD((item for item in [param]), lr=0.1)
+
+    optimizer.zero_grad()
+
+    assert isinstance(param.grad, np.ndarray)
+    np.testing.assert_allclose(param.grad, np.zeros(2))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -11,9 +11,7 @@ def test_Add():
     x = Tensor([8], requires_grad=True)
     y = Tensor([5], requires_grad=True)
     z = x + y
-    assert z.context is not None, (
-        "z.context should not be None. Check that requires_grad=True."
-    )
+    assert z.context is not None, "z.context should not be None. Check that requires_grad=True."
     assert np.all(z.data == 13)
 
     # backward test
@@ -30,9 +28,7 @@ def test_Sub():
     x = Tensor([8], requires_grad=True)
     y = Tensor([5], requires_grad=True)
     z = x - y
-    assert z.context is not None, (
-        "z.context should not be None. Check that requires_grad=True."
-    )
+    assert z.context is not None, "z.context should not be None. Check that requires_grad=True."
     assert np.all(z.data == 3)
 
     # backward test
@@ -49,9 +45,7 @@ def test_Mul():
     x = Tensor([8], requires_grad=True)
     y = Tensor([5], requires_grad=True)
     z = x * y  # Use the * operator
-    assert z.context is not None, (
-        "z.context should not be None. Check that requires_grad=True."
-    )
+    assert z.context is not None, "z.context should not be None. Check that requires_grad=True."
     assert np.all(z.data == 40)
 
     # backward test
@@ -68,9 +62,7 @@ def test_TrueDiv():
     x = Tensor([8], requires_grad=True)
     y = Tensor([2], requires_grad=True)
     z = x / y  # Use the / operator
-    assert z.context is not None, (
-        "z.context should not be None. Check that requires_grad=True."
-    )
+    assert z.context is not None, "z.context should not be None. Check that requires_grad=True."
     assert np.all(z.data == 4)
 
     # backward test
@@ -87,9 +79,7 @@ def test_MatMul():
     x = Tensor(np.array([[1, 2, 3], [4, 5, 6]]), requires_grad=True)  # 2x3 matrix
     y = Tensor(np.array([[7, 8], [9, 10], [11, 12]]), requires_grad=True)  # 3x2 matrix
     z = x @ y
-    assert z.context is not None, (
-        "z.context should not be None. Check that requires_grad=True."
-    )
+    assert z.context is not None, "z.context should not be None. Check that requires_grad=True."
     assert np.all(z.data == np.array([[58, 64], [139, 154]]))
 
     # backward test

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -18,8 +18,8 @@ def test_Add():
 
     # backward test
     z.backward(Tensor(np.ones_like(z.data)))
-    assert np.all(x.grad.data == np.array([1]))
-    assert np.all(y.grad.data == np.array([1]))
+    assert np.all(x.grad == np.array([1]))
+    assert np.all(y.grad == np.array([1]))
 
 
 def test_Sub():
@@ -37,8 +37,8 @@ def test_Sub():
 
     # backward test
     z.backward(Tensor(np.ones_like(z.data)))
-    assert np.all(x.grad.data == np.array([1]))
-    assert np.all(y.grad.data == np.array([-1]))
+    assert np.all(x.grad == np.array([1]))
+    assert np.all(y.grad == np.array([-1]))
 
 
 def test_Mul():
@@ -56,8 +56,8 @@ def test_Mul():
 
     # backward test
     z.backward(Tensor(np.ones_like(z.data)))
-    assert np.all(x.grad.data == np.array([5]))
-    assert np.all(y.grad.data == np.array([8]))
+    assert np.all(x.grad == np.array([5]))
+    assert np.all(y.grad == np.array([8]))
 
 
 def test_TrueDiv():
@@ -75,8 +75,8 @@ def test_TrueDiv():
 
     # backward test
     z.backward(Tensor(np.ones_like(z.data)))
-    assert np.allclose(x.grad.data, np.array([1 / 2]))
-    assert np.allclose(y.grad.data, np.array([-8 / 4]))
+    assert np.allclose(x.grad, np.array([1 / 2]))
+    assert np.allclose(y.grad, np.array([-8 / 4]))
 
 
 def test_MatMul():
@@ -94,5 +94,5 @@ def test_MatMul():
 
     # backward test
     z.backward(Tensor(np.ones_like(z.data)))
-    assert np.allclose(x.grad.data, np.array([[15, 19, 23], [15, 19, 23]]))
-    assert np.allclose(y.grad.data, np.array([[5, 5], [7, 7], [9, 9]]))
+    assert np.allclose(x.grad, np.array([[15, 19, 23], [15, 19, 23]]))
+    assert np.allclose(y.grad, np.array([[5, 5], [7, 7], [9, 9]]))

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -29,5 +29,5 @@ def test_backpropagation():
     The gradient of z with respect to x is the value of y (from the x * y part of the operation),
     so x.grad = [4.0, 5.0, 6.0]
     """
-    assert np.allclose(y.grad.data, [2.0, 3.0, 4.0])
-    assert np.allclose(x.grad.data, [4.0, 5.0, 6.0])
+    assert np.allclose(y.grad, [2.0, 3.0, 4.0])
+    assert np.allclose(x.grad, [4.0, 5.0, 6.0])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -31,3 +31,21 @@ def test_backpropagation():
     """
     assert np.allclose(y.grad, [2.0, 3.0, 4.0])
     assert np.allclose(x.grad, [4.0, 5.0, 6.0])
+
+
+def test_getitem_slice_backward_scatter():
+    x = Tensor(np.arange(6.0), requires_grad=True)
+
+    y = (x[2:5] * Tensor([1.0, 2.0, 3.0])).sum()
+    y.backward()
+
+    np.testing.assert_allclose(x.grad, [0.0, 0.0, 1.0, 2.0, 3.0, 0.0])
+
+
+def test_getitem_repeated_index_backward_accumulates():
+    x = Tensor(np.arange(4.0), requires_grad=True)
+
+    y = x[[1, 1, 3]].sum()
+    y.backward()
+
+    np.testing.assert_allclose(x.grad, [0.0, 2.0, 0.0, 1.0])

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from punytorch.nn.modules import Linear, Module
+from punytorch.nn.optimizers import SGD
+from punytorch.tensor import Tensor
+
+
+class TinyClassifier(Module):
+    def __init__(self):
+        self.linear = Linear(2, 2)
+        self.linear.weight.data = np.array([[0.1, -0.2], [-0.1, 0.2]], dtype=np.float64)
+        self.linear.bias.data = np.zeros(2, dtype=np.float64)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def test_tiny_classifier_learns_linearly_separable_data():
+    inputs = Tensor(
+        np.array(
+            [
+                [-2.0, -1.0],
+                [-1.5, -2.0],
+                [1.0, 2.0],
+                [2.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+    )
+    targets = Tensor(
+        np.array(
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+    )
+    model = TinyClassifier()
+    optimizer = SGD(model.parameters(), lr=0.1)
+
+    initial_loss = model(inputs).cross_entropy(targets).item()
+
+    for _ in range(80):
+        optimizer.zero_grad()
+        loss = model(inputs).cross_entropy(targets)
+        loss.backward()
+        optimizer.step()
+
+    logits = model(inputs)
+    final_loss = logits.cross_entropy(targets).item()
+    predictions = np.argmax(logits.data, axis=1)
+
+    assert final_loss < initial_loss * 0.2
+    assert predictions.tolist() == [0, 0, 1, 1]


### PR DESCRIPTION
## Summary

- Define and enforce a clearer autograd operation contract: `forward()` methods return NumPy data, `backward()` methods return gradient arrays or `None`, and `Tensor.backward()` owns accumulation.
- Fix gradient correctness for activations, losses, reductions, broadcasting, reshape, matmul, and cross-entropy.
- Fix module/optimizer correctness around deterministic parameter ordering, nested `state_dict` loading, `Linear(..., bias=False)`, and Tensor/array gradient handling.
- Add finite-difference gradient checks and a deterministic tiny training proof.

## Validation

- `uv run --no-project --python /opt/homebrew/bin/python3.12 --with pytest --with numpy --with requests python -m pytest -q -m "not dataset"` passed: `50 passed, 1 deselected`
- `git diff --check` passed

The deselected test is the existing MNIST dataset test, which requires local/downloaded dataset files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core backprop, losses, and checkpoint loading across the library; risk is mitigated by broad gradcheck and integration tests but any missed op edge case could still break training.
> 
> **Overview**
> Refactors the autograd stack so **operations work on NumPy in `forward`/`backward`** and return plain gradient arrays (or `None`); **`Tensor.backward()`** handles shape matching and gradient accumulation. Adds **`_unbroadcast`** and axis normalization so broadcasting, matmul, reductions, reshape, and transpose backprop behave correctly.
> 
> **Activations and losses** follow the same contract; **softmax** backward is vectorized (replacing nested loops), **`softmax(dim=...)`** is wired through, and **cross-entropy** supports **1D logits** with stable forward/backward. **Indexing** scatters gradients with **`np.add.at`** for repeated indices.
> 
> **NN/optimizer fixes:** deterministic **`parameters()`** without duplicates, **dotted-key `load_state_dict`** for nested/`ModuleList` models, **`Linear(..., bias=False)`** forward without adding `None` bias, and optimizers accept **`param.grad` as ndarray or `Tensor`**.
> 
> New coverage includes **finite-difference gradchecks**, module/state_dict tests, and a **tiny end-to-end training** smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8222bfc4f22a31704fe67a7f0c3ccb6fa8fcdf04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->