### PR TITLE
Fix loss tensor data contract

### DIFF
--- a/punytorch/losses.py
+++ b/punytorch/losses.py
@@ -4,25 +4,57 @@ from punytorch.tensor import Tensor
 from punytorch.ops import Operation
 
 
+def _as_array(value):
+    if isinstance(value, Tensor):
+        return value.data
+    return np.asarray(value)
+
+
+def _grad_data(grad):
+    return grad.data if isinstance(grad, Tensor) else np.asarray(grad)
+
+
+def _classification_arrays(pred, target):
+    pred_array = _as_array(pred)
+    target_array = _as_array(target)
+    original_shape = pred_array.shape
+
+    if pred_array.ndim == 1:
+        pred_array = pred_array.reshape(1, -1)
+    elif pred_array.ndim != 2:
+        raise ValueError("Expected a 1D or 2D prediction array")
+
+    if target_array.ndim == 1:
+        target_array = target_array.reshape(1, -1)
+    elif target_array.ndim != 2:
+        raise ValueError("Expected a 1D or 2D target array")
+
+    if pred_array.shape != target_array.shape:
+        raise ValueError("Predictions and targets must have the same shape")
+
+    return pred_array, target_array, original_shape
+
+
 class MSELoss(Operation):
     """
     Implements the Mean Squared Error (MSE) loss function for a neural network.
     """
 
     @staticmethod
-    def forward(y_pred: Tensor, y_true: Tensor) -> float:
+    def forward(y_pred, y_true):
         """
         Computes the forward pass of the MSE loss function.
 
         Args:
-            y_pred (Tensor): The predicted values.
-            y_true (Tensor): The true values.
+            y_pred: The predicted values.
+            y_true: The true values.
 
         Returns:
             float: The MSE loss, which is the mean of the squared differences between the predicted and true values.
         """
-        loss = np.mean((y_pred.data - y_true.data) ** 2)
-        return loss
+        y_pred_array = _as_array(y_pred)
+        y_true_array = _as_array(y_true)
+        return np.mean((y_pred_array - y_true_array) ** 2)
 
     @staticmethod
     def backward(context, grad):
@@ -37,8 +69,10 @@ class MSELoss(Operation):
             tuple: Gradients with respect to y_pred and y_true
         """
         y_pred, y_true = context.args
-        grad_pred = 2 * (y_pred.data - y_true.data) / y_pred.data.size
-        grad_data = grad.data if hasattr(grad, "data") else grad
+        y_pred_array = _as_array(y_pred)
+        y_true_array = _as_array(y_true)
+        grad_pred = 2 * (y_pred_array - y_true_array) / y_pred_array.size
+        grad_data = _grad_data(grad)
         return Tensor(grad_pred * grad_data), None
 
 
@@ -49,7 +83,7 @@ class CrossEntropyLoss(Operation):
     """
 
     @staticmethod
-    def forward(logits: Tensor, targets: Tensor) -> float:
+    def forward(logits, targets):
         """
         Computes cross entropy loss from raw logits.
 
@@ -60,8 +94,10 @@ class CrossEntropyLoss(Operation):
         Returns:
             float: Scalar loss value
         """
+        logits_array, targets_array, _ = _classification_arrays(logits, targets)
+
         # Numerical stability: Subtract max logit (prevents exp overflow)
-        shifted_logits = logits.data - np.max(logits.data, axis=1, keepdims=True)
+        shifted_logits = logits_array - np.max(logits_array, axis=1, keepdims=True)
 
         # Log-softmax implementation
         exp_logits = np.exp(shifted_logits)
@@ -69,10 +105,8 @@ class CrossEntropyLoss(Operation):
         log_softmax = shifted_logits - log_sum_exp
 
         # Cross entropy is negative sum of true_probs * log_probs
-        batch_losses = -np.sum(targets.data * log_softmax, axis=1)
-        loss = np.mean(batch_losses)
-
-        return loss
+        batch_losses = -np.sum(targets_array * log_softmax, axis=1)
+        return np.mean(batch_losses)
 
     @staticmethod
     def backward(context, grad: Tensor) -> tuple:
@@ -87,18 +121,21 @@ class CrossEntropyLoss(Operation):
             tuple: (Gradient with respect to logits, None for targets)
         """
         logits, targets = context.args
+        logits_array, targets_array, original_shape = _classification_arrays(logits, targets)
 
         # Compute softmax (reuse the stability trick)
-        shifted_logits = logits.data - np.max(logits.data, axis=1, keepdims=True)
+        shifted_logits = logits_array - np.max(logits_array, axis=1, keepdims=True)
         exp_logits = np.exp(shifted_logits)
         softmax = exp_logits / np.sum(exp_logits, axis=1, keepdims=True)
 
         # Gradient is (softmax - targets) / batch_size
-        batch_size = logits.shape[0]
-        grad_logits = (softmax - targets.data) / batch_size
+        batch_size = logits_array.shape[0]
+        grad_logits = (softmax - targets_array) / batch_size
+        grad_logits = grad_logits.reshape(original_shape)
+        grad_data = _grad_data(grad)
 
         # Scale by upstream gradient and return as Tensor
-        return Tensor(grad_logits * grad.data), None
+        return Tensor(grad_logits * grad_data), None
 
 
 class BinaryCrossEntropyLoss(Operation):
@@ -107,7 +144,7 @@ class BinaryCrossEntropyLoss(Operation):
     """
 
     @staticmethod
-    def forward(y_pred: Tensor, y_true: Tensor) -> float:
+    def forward(y_pred, y_true):
         """
         Computes the forward pass of the Binary Cross Entropy loss function.
 
@@ -120,10 +157,12 @@ class BinaryCrossEntropyLoss(Operation):
         """
         # Add small epsilon for numerical stability
         epsilon = 1e-15
-        y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
+        y_pred_array = _as_array(y_pred)
+        y_true_array = _as_array(y_true)
+        y_pred_clipped = np.clip(y_pred_array, epsilon, 1 - epsilon)
         loss = -np.mean(
-            y_true.data * np.log(y_pred_clipped)
-            + (1 - y_true.data) * np.log(1 - y_pred_clipped)
+            y_true_array * np.log(y_pred_clipped)
+            + (1 - y_true_array) * np.log(1 - y_pred_clipped)
         )
         return loss
 
@@ -140,13 +179,15 @@ class BinaryCrossEntropyLoss(Operation):
             tuple: Gradients with respect to y_pred and y_true
         """
         y_pred, y_true = context.args
+        y_pred_array = _as_array(y_pred)
+        y_true_array = _as_array(y_true)
         epsilon = 1e-15
-        y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
-        grad_pred = (y_pred_clipped - y_true.data) / (
+        y_pred_clipped = np.clip(y_pred_array, epsilon, 1 - epsilon)
+        grad_pred = (y_pred_clipped - y_true_array) / (
             y_pred_clipped * (1 - y_pred_clipped)
         )
-        grad_data = grad.data if hasattr(grad, "data") else grad
-        return Tensor(grad_pred * grad_data / y_pred.data.size), None
+        grad_data = _grad_data(grad)
+        return Tensor(grad_pred * grad_data / y_pred_array.size), None
 
 
 class CategoricalCrossEntropyLoss(Operation):
@@ -155,7 +196,7 @@ class CategoricalCrossEntropyLoss(Operation):
     """
 
     @staticmethod
-    def forward(y_pred: Tensor, y_true: Tensor) -> float:
+    def forward(y_pred, y_true):
         """
         Computes the forward pass of the Categorical Cross Entropy loss function.
 
@@ -167,10 +208,11 @@ class CategoricalCrossEntropyLoss(Operation):
             float: The Categorical Cross Entropy loss.
         """
         # Add small epsilon for numerical stability
+        y_pred_array, y_true_array, _ = _classification_arrays(y_pred, y_true)
         epsilon = 1e-15
-        y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
-        loss = -np.sum(y_true.data * np.log(y_pred_clipped))
-        return loss
+        y_pred_clipped = np.clip(y_pred_array, epsilon, 1 - epsilon)
+        batch_losses = -np.sum(y_true_array * np.log(y_pred_clipped), axis=1)
+        return np.mean(batch_losses)
 
     @staticmethod
     def backward(context, grad):
@@ -185,8 +227,10 @@ class CategoricalCrossEntropyLoss(Operation):
             tuple: Gradients with respect to y_pred and y_true
         """
         y_pred, y_true = context.args
+        y_pred_array, y_true_array, original_shape = _classification_arrays(y_pred, y_true)
         epsilon = 1e-15
-        y_pred_clipped = np.clip(y_pred.data, epsilon, 1 - epsilon)
-        grad_pred = -y_true.data / y_pred_clipped
-        grad_data = grad.data if hasattr(grad, "data") else grad
+        y_pred_clipped = np.clip(y_pred_array, epsilon, 1 - epsilon)
+        grad_pred = -y_true_array / y_pred_clipped / y_pred_array.shape[0]
+        grad_pred = grad_pred.reshape(original_shape)
+        grad_data = _grad_data(grad)
         return Tensor(grad_pred * grad_data), None

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from punytorch.ops import Function
 from punytorch.losses import (
     MSELoss,
     CrossEntropyLoss,
@@ -10,41 +11,61 @@ from punytorch.losses import (
 from punytorch.tensor import Tensor
 
 
+def loss_backward(loss_cls, y_pred, y_true, upstream=1.0):
+    context = Function(loss_cls, y_pred, y_true)
+    grad_pred, grad_true = loss_cls.backward(context, Tensor(upstream))
+    assert grad_true is None
+    return grad_pred.data
+
+
 def test_MSELoss():
     y_true = Tensor([1.0, 2.0, 3.0])
-    y_pred = Tensor([1.0, 2.0, 3.0])
-    assert np.isclose(MSELoss.forward(y_pred.data, y_true.data).data, Tensor(0.0).data)
+    y_pred = Tensor([1.0, 3.0, 5.0])
+    assert np.isclose(MSELoss.forward(y_pred, y_true), 5.0 / 3.0)
+    assert np.isclose(MSELoss.forward(y_pred.data, y_true.data), 5.0 / 3.0)
     assert np.allclose(
-        MSELoss.backward(y_pred.data, y_true.data).data, Tensor([0.0, 0.0, 0.0]).data
+        loss_backward(MSELoss, y_pred, y_true),
+        np.array([0.0, 2.0 / 3.0, 4.0 / 3.0]),
     )
 
 
 @pytest.mark.gpt
 @pytest.mark.mnist
 def test_CrossEntropyLoss():
-    # create and test both 1-dimensional and 2-dimensional tensors
     y_true_1d = Tensor([1.0, 0.0, 0.0])
-    y_pred_1d = Tensor([0.7, 0.2, 0.1])
+    logits_1d = Tensor([0.7, 0.2, 0.1])
     y_true_2d = Tensor([[1.0, 0.0, 0.0]])
-    y_pred_2d = Tensor([[0.7, 0.2, 0.1]])
+    logits_2d = Tensor([[0.7, 0.2, 0.1]])
 
-    # test of 1-dimensional tensor
     assert np.isclose(
-        CrossEntropyLoss.forward(y_pred_1d.data, y_true_1d.data).data,
-        0.2559831829678749,
-    )
-    assert np.allclose(
-        CrossEntropyLoss.backward(y_pred_1d.data, y_true_1d.data).data,
-        np.array([-0.17867886, 0.09380268, 0.08487618]),
-    )
-
-    # test of 2-dimensional tensor
-    assert np.isclose(
-        CrossEntropyLoss.forward(y_pred_2d.data, y_true_2d.data).data,
+        CrossEntropyLoss.forward(logits_1d, y_true_1d),
         0.7679495489036248,
     )
     assert np.allclose(
-        CrossEntropyLoss.backward(y_pred_2d.data, y_true_2d.data).data,
+        loss_backward(CrossEntropyLoss, logits_1d, y_true_1d),
+        np.array([-0.53603657, 0.28140804, 0.25462853]),
+    )
+
+    assert np.isclose(
+        CrossEntropyLoss.forward(logits_2d.data, y_true_2d.data),
+        0.7679495489036248,
+    )
+    assert np.allclose(
+        loss_backward(CrossEntropyLoss, logits_2d, y_true_2d),
+        np.array([[-0.53603657, 0.28140804, 0.25462853]]),
+    )
+
+
+def test_CrossEntropyLoss_tensor_graph():
+    logits = Tensor([[0.7, 0.2, 0.1]], requires_grad=True)
+    targets = Tensor([[1.0, 0.0, 0.0]])
+
+    loss = logits.cross_entropy(targets)
+    assert np.isclose(loss.data, 0.7679495489036248)
+
+    loss.backward()
+    assert np.allclose(
+        logits.grad,
         np.array([[-0.53603657, 0.28140804, 0.25462853]]),
     )
 
@@ -53,12 +74,12 @@ def test_BinaryCrossEntropyLoss():
     y_true = Tensor([1.0, 1.0, 1.0])
     y_pred = Tensor([0.9, 0.8, 0.9])
     assert np.isclose(
-        BinaryCrossEntropyLoss.forward(y_pred.data, y_true.data).data,
+        BinaryCrossEntropyLoss.forward(y_pred, y_true),
         0.14462152754328741,
     )
     assert np.allclose(
-        BinaryCrossEntropyLoss.backward(y_pred.data, y_true.data),
-        np.array([-1.11111111, -1.25, -1.11111111]),
+        loss_backward(BinaryCrossEntropyLoss, y_pred, y_true),
+        np.array([-0.37037037, -0.41666667, -0.37037037]),
     )
 
 
@@ -66,10 +87,10 @@ def test_CategoricalCrossEntropyLoss():
     y_true = Tensor([1.0, 0.0, 0.0])
     y_pred = Tensor([0.7, 0.2, 0.1])
     assert np.isclose(
-        CategoricalCrossEntropyLoss.forward(y_pred.data, y_true.data).data,
+        CategoricalCrossEntropyLoss.forward(y_pred, y_true),
         0.35667494393873245,
     )
     assert np.allclose(
-        CategoricalCrossEntropyLoss.backward(y_pred.data, y_true.data),
+        loss_backward(CategoricalCrossEntropyLoss, y_pred, y_true),
         np.array([-1.42857143, 0.0, 0.0]),
     )


### PR DESCRIPTION
## Summary
- Make loss `forward` methods accept Tensor or ndarray inputs, unwrap to NumPy, and return scalar NumPy data for Tensor wrapping.
- Keep `backward(context, grad)` aligned with autograd by returning Tensor gradients and `None` for targets.
- Update loss tests to exercise the operation-style contract, including raw-logit cross entropy with one-hot targets through `Tensor.cross_entropy`.

## Tests
- `.venv/bin/python -m pytest tests/test_loss.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Training math changed for cross-entropy (batch mean and 1D handling) and all losses now depend on the shared input contract, so any caller passing wrong shapes or expecting old scalar-sum CE could break silently.
> 
> **Overview**
> Loss `forward`/`backward` now go through shared helpers so inputs can be **`Tensor` or `ndarray`**, upstream grads are normalized consistently, and **`forward` returns scalar NumPy** for the autograd wrapper.
> 
> **Cross-entropy family** changes are the behavioral ones: **`_classification_arrays`** promotes 1D logits/targets to a batch row, validates shapes, and restores the original layout in **`backward`**. **`CrossEntropyLoss`** and **`CategoricalCrossEntropyLoss`** now **mean over the batch** (and scale gradients by batch size), which updates expected values versus the old 1D path. **MSE** and **binary CE** follow the same unwrap/`_grad_data` pattern without changing their reduction semantics beyond test fixes.
> 
> **`tests/test_loss.py`** now drives losses through **`Function` + `backward(context, grad)`**, checks Tensor and raw array inputs, and adds an end-to-end **`Tensor.cross_entropy` → `backward()`** test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f247f1e019e5047a22d7852e949d9a2069df0819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->