### PR TITLE
Fix activation tensor data contract

### DIFF
--- a/punytorch/activations.py
+++ b/punytorch/activations.py
@@ -2,6 +2,22 @@ import numpy as np
 from punytorch.ops import Operation
 
 
+def _as_array(value):
+    if isinstance(value, np.ndarray):
+        return value
+    data = getattr(value, "data", None)
+    if isinstance(data, np.ndarray):
+        return data
+    return np.asarray(value)
+
+
+def _grad_array(grad, shape):
+    grad_data = _as_array(grad)
+    if np.ndim(grad_data) == 0:
+        return np.ones(shape, dtype=np.float64) * grad_data
+    return grad_data
+
+
 class ReLU(Operation):
     """
     Implements the ReLU (Rectified Linear Unit) activation function for a neural network.
@@ -18,7 +34,7 @@ class ReLU(Operation):
         Returns:
             numpy.ndarray: The output after applying the ReLU function, which is max(0, x).
         """
-        return np.maximum(0, x.data)
+        return np.maximum(0, _as_array(x))
 
     @staticmethod
     def backward(context, grad):
@@ -35,11 +51,9 @@ class ReLU(Operation):
         """
         from punytorch.tensor import Tensor
 
-        x = context.args[0].data
-        # grad wasn't broadcasting to the same shape as x, so:
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
-        grad_data = np.ones_like(x) if np.isscalar(grad_data) else grad_data
-        return Tensor((x > 0).astype(np.float64) * grad_data), None
+        x = _as_array(context.args[0])
+        grad_data = _grad_array(grad, x.shape)
+        return (Tensor((x > 0).astype(np.float64) * grad_data),)
 
 
 class Sigmoid(Operation):
@@ -58,7 +72,8 @@ class Sigmoid(Operation):
         Returns:
             numpy.ndarray: The output after applying the Sigmoid function, which is 1 / (1 + exp(-x)).
         """
-        return 1 / (1 + np.exp(-x.data))
+        x = _as_array(x)
+        return 1 / (1 + np.exp(-x))
 
     @staticmethod
     def backward(context, grad):
@@ -75,10 +90,10 @@ class Sigmoid(Operation):
         """
         from punytorch.tensor import Tensor
 
-        x = context.args[0].data
+        x = _as_array(context.args[0])
         sigmoid_x = 1 / (1 + np.exp(-x))
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
-        return Tensor(sigmoid_x * (1 - sigmoid_x) * grad_data), None
+        grad_data = _grad_array(grad, x.shape)
+        return (Tensor(sigmoid_x * (1 - sigmoid_x) * grad_data),)
 
 
 class Softmax(Operation):
@@ -101,7 +116,7 @@ class Softmax(Operation):
         """
         if dim is None:
             dim = -1
-        input_data = x.data if hasattr(x, "data") else x
+        input_data = _as_array(x)
         e_x = np.exp(
             input_data - np.max(input_data, axis=dim, keepdims=True)
         )  # subtract max(x) for numerical stability
@@ -126,16 +141,10 @@ class Softmax(Operation):
         """
         from punytorch.tensor import Tensor
 
-        x = context.args[0].data
-        softmax_x = np.exp(x - np.max(x))
-        softmax_x /= np.sum(softmax_x, axis=0)
-        grad_data = grad.data if isinstance(grad, Tensor) else grad
-        grad_data = np.ones_like(x) if np.isscalar(grad_data) else grad_data
-        grad_input = np.zeros_like(x)
-        for i in range(len(x)):
-            for j in range(len(x)):
-                if i == j:
-                    grad_input[i] += grad_data[j] * softmax_x[i] * (1 - softmax_x[j])
-                else:
-                    grad_input[i] -= grad_data[j] * softmax_x[i] * softmax_x[j]
-        return Tensor(grad_input), None
+        x = _as_array(context.args[0])
+        softmax_x = Softmax.forward(x)
+        grad_data = _grad_array(grad, x.shape)
+        grad_input = softmax_x * (
+            grad_data - np.sum(grad_data * softmax_x, axis=-1, keepdims=True)
+        )
+        return (Tensor(grad_input),)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from punytorch.activations import ReLU, Sigmoid, Softmax
 from punytorch.tensor import Tensor
 
 
@@ -23,12 +24,39 @@ def test_Sigmoid():
     assert np.allclose(x.grad, y.data * (1 - y.data))
 
 
-# @pytest.mark.gpt
-# def test_Softmax():
-#     x = Tensor(np.array([0, 1, 2, 3, 4, 5]))
-#     y = x.softmax()
-#     assert np.allclose(y.data, np.exp(x.data) / np.sum(np.exp(x.data)))
-#     y.backward(np.ones_like(x.data))
-#     # The gradient of softmax is complex and depends on the input values.
-#     # Here, we're just checking that the gradient has the same shape as the input.
-#     assert x.grad.shape == x.data.shape
+def test_activation_forwards_accept_ndarrays():
+    x = np.array([-1.0, 0.0, 1.0])
+
+    assert np.allclose(ReLU.forward(x), np.array([0.0, 0.0, 1.0]))
+    assert np.allclose(Sigmoid.forward(x), 1 / (1 + np.exp(-x)))
+    assert np.allclose(Softmax.forward(x).sum(), 1.0)
+
+
+def test_sigmoid_backward_with_upstream_gradient():
+    x = Tensor(np.array([0.0, 1.0, 2.0]), requires_grad=True)
+    y = x.sigmoid()
+    upstream = np.array([1.0, 2.0, 3.0])
+
+    y.backward(upstream)
+
+    assert np.allclose(x.grad, upstream * y.data * (1 - y.data))
+
+
+@pytest.mark.gpt
+def test_Softmax():
+    x = Tensor(np.array([[0.0, 1.0, 2.0], [2.0, 1.0, 0.0]]), requires_grad=True)
+    y = x.softmax()
+
+    expected = np.exp(x.data - np.max(x.data, axis=-1, keepdims=True))
+    expected /= np.sum(expected, axis=-1, keepdims=True)
+    assert np.allclose(y.data, expected)
+    assert y.data.shape == x.data.shape
+    assert np.allclose(y.data.sum(axis=-1), np.ones(x.data.shape[0]))
+
+    upstream = np.array([[1.0, 0.0, -1.0], [0.5, -0.5, 1.0]])
+    y.backward(upstream)
+    expected_grad = expected * (
+        upstream - np.sum(upstream * expected, axis=-1, keepdims=True)
+    )
+    assert x.grad.shape == x.data.shape
+    assert np.allclose(x.grad, expected_grad)


### PR DESCRIPTION
## Summary
- Normalize activation inputs so ReLU, Sigmoid, and Softmax forwards accept either Tensor-like objects or raw NumPy arrays.
- Make activation backwards consistently unwrap upstream gradients and return shape-preserving Tensor gradients.
- Add regression coverage for ndarray activation forwards, sigmoid backward with an upstream gradient, and batched softmax forward/backward behavior.

## Tests
- `uv run pytest tests/test_activation.py -q` (blocked locally: uv cache at `/Users/josh/.cache/uv` is not writable in the sandbox)
- `/Users/josh/code/punytorch/.venv/bin/python -m pytest tests/test_activation.py -q` -> `5 passed in 0.07s`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Softmax backward is rewritten and activation backward return shapes changed, which can affect any model using softmax in the autograd path; scope is limited to activations with new regression tests.
> 
> **Overview**
> Activations now share **`_as_array`** and **`_grad_array`** so ReLU, Sigmoid, and Softmax **forwards** accept Tensors or raw NumPy arrays, and **backwards** unwrap upstream gradients (including scalars) to the input shape.
> 
> **Backward return values** are normalized to a single-element tuple `(Tensor(...),)` instead of `(Tensor(...), None)`, aligning with the autograd contract. **Softmax backward** is replaced with a vectorized last-axis Jacobian formula that reuses **`Softmax.forward`**, fixing incorrect behavior for multi-dimensional / batched inputs.
> 
> Tests add ndarray forward coverage, sigmoid backward with a custom upstream gradient, and batched softmax forward/backward assertions (replacing the old commented softmax test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4281bc25ff5bc6604bcee97a776acc26c41504b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->