### PR TITLE
Implement no_grad graph suppression

### DIFF
--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import wraps
+
 import numpy as np
 
 from punytorch.activations import ReLU, Sigmoid, Softmax
@@ -21,6 +23,8 @@ from punytorch.ops import (
 
 
 class Tensor:
+    _compute_grad = True
+
     def __init__(self, data, requires_grad=False):
         if isinstance(data, np.ndarray):
             self.data = data
@@ -43,11 +47,12 @@ class Tensor:
         return self.data.shape[0]
 
     def __getitem__(self, index):
+        requires_grad = Tensor._should_track_grad(self)
         # Create a new tensor from the indexed data
-        result = Tensor(self.data[index], requires_grad=self.requires_grad)
+        result = Tensor(self.data[index], requires_grad=requires_grad)
 
         # If this tensor requires gradients, we need to set up the backward connection
-        if self.requires_grad:
+        if requires_grad:
             # We need to create a custom indexing operation that can propagate gradients
             from punytorch.ops import Function
 
@@ -73,8 +78,9 @@ class Tensor:
     def T(self):
         from punytorch.ops import Transpose, Function
 
-        result = Tensor(Transpose.forward(self), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        requires_grad = Tensor._should_track_grad(self)
+        result = Tensor(Transpose.forward(self), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Transpose, self)
         return result
 
@@ -92,7 +98,7 @@ class Tensor:
         axes = list(range(self.data.ndim))
         axes[dim0], axes[dim1] = axes[dim1], axes[dim0]
         data = self.data.transpose(axes)
-        return Tensor(data, requires_grad=self.requires_grad)
+        return Tensor(data, requires_grad=Tensor._should_track_grad(self))
 
     def tolist(self):
         return self.data.tolist()
@@ -122,7 +128,7 @@ class Tensor:
         Returns:
             Tensor: A copy of the tensor.
         """
-        return Tensor(self.data.copy(), requires_grad=self.requires_grad)
+        return Tensor(self.data.copy(), requires_grad=Tensor._should_track_grad(self))
 
     @staticmethod
     def stack(tensors, axis=0):
@@ -165,10 +171,17 @@ class Tensor:
             return data
         return Tensor(data)
 
+    @staticmethod
+    def _should_track_grad(*values):
+        return Tensor._compute_grad and any(
+            isinstance(value, Tensor) and value.requires_grad for value in values
+        )
+
     """
     ML OPS
     """
 
+    @staticmethod
     def no_grad():
         """
         This context manager can temporarily disable gradient computation.
@@ -176,17 +189,20 @@ class Tensor:
 
         class NoGradContext:
             def __call__(self, func):
+                @wraps(func)
                 def wrapper(*args, **kwargs):
-                    with NoGradContext():
+                    with Tensor.no_grad():
                         return func(*args, **kwargs)
 
                 return wrapper
 
             def __enter__(self):
+                self._previous_compute_grad = Tensor._compute_grad
                 Tensor._compute_grad = False
+                return self
 
             def __exit__(self, exc_type, exc_value, traceback):
-                Tensor._compute_grad = True
+                Tensor._compute_grad = self._previous_compute_grad
 
         return NoGradContext()
 
@@ -212,8 +228,9 @@ class Tensor:
         target = self.prod((s for s in shape if s != -1))
         shape = tuple(curr // target if s == -1 else s for s in shape)
 
-        result = Tensor(Reshape.forward(self, shape), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        requires_grad = Tensor._should_track_grad(self)
+        result = Tensor(Reshape.forward(self, shape), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Reshape, self, shape)
         return result
 
@@ -232,10 +249,11 @@ class Tensor:
         Returns:
             Tensor: Sum result with proper gradient tracking.
         """
+        requires_grad = Tensor._should_track_grad(self)
         result = Tensor(
-            Sum.forward(self, axis, keepdims), requires_grad=self.requires_grad
+            Sum.forward(self, axis, keepdims), requires_grad=requires_grad
         )
-        if self.requires_grad:
+        if requires_grad:
             result.context = Function(Sum, self, axis, keepdims)
         return result
 
@@ -250,10 +268,11 @@ class Tensor:
         Returns:
             Tensor: Mean result with proper gradient tracking.
         """
+        requires_grad = Tensor._should_track_grad(self)
         result = Tensor(
-            Mean.forward(self, axis, keepdims), requires_grad=self.requires_grad
+            Mean.forward(self, axis, keepdims), requires_grad=requires_grad
         )
-        if self.requires_grad:
+        if requires_grad:
             result.context = Function(Mean, self, axis, keepdims)
         return result
 
@@ -268,10 +287,11 @@ class Tensor:
         Returns:
             Tensor: Max result with proper gradient tracking.
         """
+        requires_grad = Tensor._should_track_grad(self)
         result = Tensor(
-            Max.forward(self, axis, keepdims), requires_grad=self.requires_grad
+            Max.forward(self, axis, keepdims), requires_grad=requires_grad
         )
-        if self.requires_grad:
+        if requires_grad:
             result.context = Function(Max, self, axis, keepdims)
         return result
 
@@ -281,58 +301,58 @@ class Tensor:
 
     def __add__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Add.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(Add.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Add, self, other)
-            result.requires_grad = True
         return result
 
     def __sub__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Sub.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(Sub.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Sub, self, other)
-            result.requires_grad = True
         return result
 
     def __mul__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Mul.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(Mul.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Mul, self, other)
-            result.requires_grad = True
         return result
 
     def __truediv__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(TrueDiv.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(TrueDiv.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(TrueDiv, self, other)
-            result.requires_grad = True
         return result
 
     def __mod__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Mod.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(Mod.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Mod, self, other)
-            result.requires_grad = True
         return result
 
     def __pow__(self, other) -> "Tensor":
         other = Tensor.ensure_tensor(other)
-        result = Tensor(Pow.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(Pow.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Pow, self, other)
-            result.requires_grad = True
         return result
 
     def __matmul__(self, other):
         other = Tensor.ensure_tensor(other)
-        result = Tensor(MatMul.forward(self, other))
-        if self.requires_grad or other.requires_grad:
+        requires_grad = Tensor._should_track_grad(self, other)
+        result = Tensor(MatMul.forward(self, other), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(MatMul, self, other)
-            result.requires_grad = True
         return result
 
     # Right-hand operators for scalar operations
@@ -367,8 +387,9 @@ class Tensor:
         return f"tensor({self.data})"
 
     def tanh(self):
-        result = Tensor(Tanh.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        requires_grad = Tensor._should_track_grad(self)
+        result = Tensor(Tanh.forward(self.data), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Tanh, self)
         return result
 
@@ -382,20 +403,23 @@ class Tensor:
         self.grad = np.zeros_like(self.data, dtype=float)
 
     def relu(self):
-        result = Tensor(ReLU.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        requires_grad = Tensor._should_track_grad(self)
+        result = Tensor(ReLU.forward(self.data), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(ReLU, self)
         return result
 
     def sigmoid(self):
-        result = Tensor(Sigmoid.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        requires_grad = Tensor._should_track_grad(self)
+        result = Tensor(Sigmoid.forward(self.data), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Sigmoid, self)
         return result
 
     def softmax(self):
-        result = Tensor(Softmax.forward(self.data), requires_grad=self.requires_grad)
-        if self.requires_grad:
+        requires_grad = Tensor._should_track_grad(self)
+        result = Tensor(Softmax.forward(self.data), requires_grad=requires_grad)
+        if requires_grad:
             result.context = Function(Softmax, self)
         return result
 
@@ -413,8 +437,12 @@ class Tensor:
         from punytorch.ops import Function
 
         targets = Tensor.ensure_tensor(targets)
-        result = Tensor(CrossEntropyLoss.forward(self, targets), requires_grad=True)
-        if self.requires_grad or targets.requires_grad:
+        requires_grad = Tensor._compute_grad
+        should_attach_context = Tensor._should_track_grad(self, targets)
+        result = Tensor(
+            CrossEntropyLoss.forward(self, targets), requires_grad=requires_grad
+        )
+        if should_attach_context:
             result.context = Function(CrossEntropyLoss, self, targets)
         return result
 
@@ -450,7 +478,10 @@ class Tensor:
         Converts the tensor to a 64-bit integer tensor.
         """
         if self.dtype is not np.int64:
-            return Tensor(self.data.astype(np.int64), requires_grad=self.requires_grad)
+            return Tensor(
+                self.data.astype(np.int64),
+                requires_grad=Tensor._should_track_grad(self),
+            )
         return self
 
     def to(self, device):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -31,3 +31,63 @@ def test_backpropagation():
     """
     assert np.allclose(y.grad.data, [2.0, 3.0, 4.0])
     assert np.allclose(x.grad.data, [4.0, 5.0, 6.0])
+
+
+def test_no_grad_operations_do_not_track_gradients():
+    x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+
+    with Tensor.no_grad():
+        y = x + 1
+        z = y.sum()
+        relu = x.relu()
+
+    for result in (y, z, relu):
+        assert result.requires_grad is False
+        assert result.context is None
+
+
+def test_no_grad_decorator_disables_gradient_tracking():
+    x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+
+    @Tensor.no_grad()
+    def add_and_sum(tensor):
+        return (tensor + 1).sum()
+
+    result = add_and_sum(x)
+
+    assert result.requires_grad is False
+    assert result.context is None
+
+
+def test_no_grad_nested_context_restores_outer_state():
+    x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+
+    with Tensor.no_grad():
+        with Tensor.no_grad():
+            inner = x + 1
+        outer = x * 2
+
+    normal = x + 3
+
+    assert inner.requires_grad is False
+    assert inner.context is None
+    assert outer.requires_grad is False
+    assert outer.context is None
+    assert normal.requires_grad is True
+    assert normal.context is not None
+
+
+def test_no_grad_does_not_disable_later_backpropagation():
+    x = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+
+    with Tensor.no_grad():
+        ignored = (x * 10).sum()
+
+    z = (x * 2).sum()
+    z.backward()
+
+    assert ignored.requires_grad is False
+    assert ignored.context is None
+    assert z.requires_grad is True
+    assert z.context is not None
+    assert np.allclose(x.grad.data, [2.0, 2.0, 2.0])


### PR DESCRIPTION
## Summary
- Make `Tensor.no_grad()` suppress autograd graph creation for tensor operations.
- Return operation results with `requires_grad=False` while no-grad mode is active.
- Preserve normal gradient tracking after leaving the context, including nested contexts and decorator use.

## Tests
- `uv run pytest tests/test_tensor.py tests/test_ops.py -q` (blocked: uv cache permission for `/Users/josh/.cache/uv`)
- `/Users/josh/code/punytorch/.venv/bin/python -m pytest tests/test_tensor.py tests/test_ops.py -q` (11 passed in 0.05s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core autograd wiring for many tensor paths; incorrect gating could silently break training or leak graphs, though behavior is covered by new tests.
> 
> **Overview**
> **`Tensor.no_grad()`** now actually stops building the autograd graph: a class-level **`_compute_grad`** flag is toggled in the context manager (with **nested restore** of the previous value), and a new **`_should_track_grad`** helper gates whether ops set **`requires_grad`** and attach **`Function`** contexts.
> 
> Operations across indexing, transpose, reductions, binary ops, activations, reshape, clone, **`long`**, and **`cross_entropy`** were switched from checking only per-tensor **`requires_grad`** to honoring **`_compute_grad`**. The **`no_grad`** decorator was fixed to use **`@wraps`**, enter via **`Tensor.no_grad()`**, and return **`self`** from **`__enter__`**.
> 
> New tests cover context and decorator behavior, nested contexts, and that backprop still works after leaving **`no_grad`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe61bb8c59655feaf514d6c403917822a515734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->