### PR TITLE
Update README uv workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ The goal is to have something very simple that will let me implement and experim
 
 # Example usage
 
-1. If poetry is not installed, install it via: `curl -sSL https://install.python-poetry.org | python -`
+1. Install uv if you do not already have it: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
-2.  Run `poetry install` to install the dependencies
+2. Run `uv sync` to install the dependencies
 
-3. Run `poetry shell` to activate the virtual environment
-
-4. Run `python examples/mnist.py` to train a simple model on the MNIST dataset
+3. Run `uv run python examples/mnist.py` to train a simple model on the MNIST dataset
 
 # FAQs
 > can it run an LLM?


### PR DESCRIPTION
## Summary
- Replace the README's Poetry setup instructions with uv-based setup.
- Point the example command at `uv run python examples/mnist.py`.

## Validation
- `rg -n "poetry|Poetry" README.md pyproject.toml uv.lock` returned no matches.
- `uv run pytest` passed: 53 tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README; no runtime or dependency logic is modified in this diff.
> 
> **Overview**
> Updates the **Example usage** section so new contributors install and run the project with **uv** instead of Poetry.
> 
> The numbered steps now cover installing uv, running `uv sync` for dependencies, and launching the MNIST example with `uv run python examples/mnist.py`. The old Poetry install, `poetry install`, `poetry shell`, and bare `python` invocation are removed from the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4e1726aec447478448d76d25f403d16b68fd83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->