### PR TITLE
Add stack and cat gradients

### DIFF
--- a/punytorch/ops.py
+++ b/punytorch/ops.py
@@ -312,6 +312,56 @@ class Reshape(Operation):
         return grad_data.reshape(x.shape), None
 
 
+class Stack(Operation):
+    """
+    Implements tensor stack operation with proper gradient flow.
+    """
+
+    @staticmethod
+    def forward(*args):
+        *arrays, axis = args
+        return np.stack(arrays, axis=axis)
+
+    @staticmethod
+    def backward(context, grad):
+        *tensors, axis = context.args
+        grad_data = np.asarray(grad, dtype=np.float64)
+        axis = axis if axis >= 0 else axis + grad_data.ndim
+
+        grads = [
+            np.take(grad_data, index, axis=axis).reshape(tensor.data.shape) for index, tensor in enumerate(tensors)
+        ]
+        return (*grads, None)
+
+
+class Cat(Operation):
+    """
+    Implements tensor concatenation operation with proper gradient flow.
+    """
+
+    @staticmethod
+    def forward(*args):
+        *arrays, axis = args
+        return np.concatenate(arrays, axis=axis)
+
+    @staticmethod
+    def backward(context, grad):
+        *tensors, axis = context.args
+        grad_data = np.asarray(grad, dtype=np.float64)
+        axis = axis if axis >= 0 else axis + grad_data.ndim
+
+        grads = []
+        start = 0
+        for tensor in tensors:
+            end = start + tensor.data.shape[axis]
+            slices = [slice(None)] * grad_data.ndim
+            slices[axis] = slice(start, end)
+            grads.append(grad_data[tuple(slices)].reshape(tensor.data.shape))
+            start = end
+
+        return (*grads, None)
+
+
 class Sum(Operation):
     """
     Implements tensor sum reduction with proper gradient flow.

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -5,6 +5,7 @@ import numpy as np
 from punytorch.activations import ReLU, Sigmoid, Softmax
 from punytorch.ops import (
     Add,
+    Cat,
     Function,
     MatMul,
     Max,
@@ -13,6 +14,7 @@ from punytorch.ops import (
     Mul,
     Pow,
     Reshape,
+    Stack,
     Sub,
     Sum,
     Tanh,
@@ -154,9 +156,12 @@ class Tensor:
 
     @staticmethod
     def stack(tensors, axis=0):
-        arrays = [t.data for t in tensors]
-        stacked_array = np.stack(arrays, axis)
-        return Tensor(stacked_array)
+        tensors = [Tensor.ensure_tensor(t) for t in tensors]
+        track = Tensor._should_track(*tensors)
+        result = Tensor(Stack.forward(*[t.data for t in tensors], axis), requires_grad=track)
+        if track:
+            result.context = Function(Stack, *tensors, axis)
+        return result
 
     def detach(self):
         """
@@ -476,8 +481,12 @@ class Tensor:
 
     @staticmethod
     def cat(tensors, dim=0):
-        arrays = [t.data for t in tensors]
-        return Tensor(np.concatenate(arrays, axis=dim))
+        tensors = [Tensor.ensure_tensor(t) for t in tensors]
+        track = Tensor._should_track(*tensors)
+        result = Tensor(Cat.forward(*[t.data for t in tensors], dim), requires_grad=track)
+        if track:
+            result.context = Function(Cat, *tensors, dim)
+        return result
 
     def long(self):
         """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -49,3 +49,47 @@ def test_getitem_repeated_index_backward_accumulates():
     y.backward()
 
     np.testing.assert_allclose(x.grad, [0.0, 2.0, 0.0, 1.0])
+
+
+def test_stack_backward_propagates_to_sources():
+    x = Tensor([1.0, 2.0], requires_grad=True)
+    y = Tensor([3.0, 4.0], requires_grad=True)
+
+    z = Tensor.stack([x, y]).sum()
+    z.backward()
+
+    np.testing.assert_allclose(x.grad, [1.0, 1.0])
+    np.testing.assert_allclose(y.grad, [1.0, 1.0])
+
+
+def test_stack_backward_respects_axis():
+    x = Tensor([1.0, 2.0], requires_grad=True)
+    y = Tensor([3.0, 4.0], requires_grad=True)
+
+    z = (Tensor.stack([x, y], axis=-1) * Tensor([[1.0, 3.0], [2.0, 4.0]])).sum()
+    z.backward()
+
+    np.testing.assert_allclose(x.grad, [1.0, 2.0])
+    np.testing.assert_allclose(y.grad, [3.0, 4.0])
+
+
+def test_cat_backward_propagates_to_sources():
+    x = Tensor([1.0, 2.0], requires_grad=True)
+    y = Tensor([3.0, 4.0], requires_grad=True)
+
+    z = Tensor.cat([x, y]).sum()
+    z.backward()
+
+    np.testing.assert_allclose(x.grad, [1.0, 1.0])
+    np.testing.assert_allclose(y.grad, [1.0, 1.0])
+
+
+def test_cat_backward_respects_dim():
+    x = Tensor([[1.0], [2.0]], requires_grad=True)
+    y = Tensor([[3.0, 4.0], [5.0, 6.0]], requires_grad=True)
+
+    z = (Tensor.cat([x, y], dim=-1) * Tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])).sum()
+    z.backward()
+
+    np.testing.assert_allclose(x.grad, [[1.0], [4.0]])
+    np.testing.assert_allclose(y.grad, [[2.0, 3.0], [5.0, 6.0]])


### PR DESCRIPTION
## Summary

Fixes `Tensor.stack` and `Tensor.cat` so they preserve autograd context instead of returning detached leaf tensors.

## Root Cause

Both helpers built raw NumPy arrays and returned fresh `Tensor` instances without a `Function` context, so downstream backward passes could not propagate gradients to the source tensors.

## Changes

- Added `Stack` and `Cat` autograd operations.
- Wired `Tensor.stack` and `Tensor.cat` through those operations when any input requires gradients.
- Added regression tests for stack/cat gradient propagation, including non-default axis/dim cases.

## Validation

- `uv run pytest tests/test_tensor.py` → 8 passed
- `uv run pytest` → 57 passed
- `uv run black --check punytorch/ops.py punytorch/tensor.py tests/test_tensor.py` → clean

Note: full-project Black still reports pre-existing formatting drift in untouched `tests/conftest.py` and `tests/test_mnist.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized autograd fix with tests; no auth, I/O, or API surface changes beyond correct gradients for stack/cat.
> 
> **Overview**
> **`Tensor.stack` and `Tensor.cat` now participate in autograd** when any input has `requires_grad=True`, instead of returning detached results built only from NumPy.
> 
> New **`Stack`** and **`Cat`** `Operation` classes in `ops.py` implement forward (`np.stack` / `np.concatenate`) and backward: stack splits the upstream gradient with `np.take` along the stack axis; cat slices the gradient along the concat dimension for each input. **`tensor.py`** routes the static helpers through `Function(Stack|Cat, …)` using the same `_should_track` pattern as other ops.
> 
> Regression tests cover gradient flow to all sources and non-default **`axis`** / **`dim`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b208b389d73862470ab063b6ff2a645b0c92cb04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->