### PR TITLE
Add autograd support for abs

### DIFF
--- a/punytorch/ops.py
+++ b/punytorch/ops.py
@@ -250,6 +250,24 @@ class Tanh(Operation):
         return (grad_tanh * grad_data,)
 
 
+class Abs(Operation):
+    @staticmethod
+    def forward(x):
+        """
+        z = abs(x)
+        """
+        return np.abs(x)
+
+    @staticmethod
+    def backward(context, grad):
+        """
+        d(abs(x))/dx = sign(x), with subgradient 0 at x == 0.
+        """
+        x = context.args[0]
+        grad_data = np.asarray(grad, dtype=np.float64)
+        return (grad_data * np.sign(x.data),)
+
+
 class Transpose(Operation):
     """
     Implements matrix transpose operation with proper gradient flow.

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from punytorch.activations import ReLU, Sigmoid, Softmax
 from punytorch.ops import (
+    Abs,
     Add,
     Function,
     MatMul,
@@ -386,7 +387,11 @@ class Tensor:
     """
 
     def __abs__(self) -> "Tensor":
-        return Tensor(np.abs(self.data))
+        track = Tensor._should_track(self)
+        result = Tensor(Abs.forward(self.data), requires_grad=track)
+        if track:
+            result.context = Function(Abs, self)
+        return result
 
     def __neg__(self) -> "Tensor":
         return self * -1

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -49,3 +49,12 @@ def test_getitem_repeated_index_backward_accumulates():
     y.backward()
 
     np.testing.assert_allclose(x.grad, [0.0, 2.0, 0.0, 1.0])
+
+
+def test_abs_backward_uses_sign_subgradient():
+    x = Tensor(np.array([-2.0, 0.0, 3.0]), requires_grad=True)
+
+    y = abs(x).sum()
+    y.backward()
+
+    np.testing.assert_allclose(x.grad, [-1.0, 0.0, 1.0])


### PR DESCRIPTION
## Summary

- Add a differentiable `Abs` operation that forwards through `np.abs` and backpropagates `sign(x)`.
- Wire `Tensor.__abs__` through autograd tracking instead of returning an untracked leaf tensor.
- Add regression coverage for `abs(x).sum().backward()`, including the zero subgradient case.

## Why

`abs(Tensor)` previously returned `Tensor(np.abs(...))` without a context, so gradients stopped at the absolute value. This broke common formulas such as L1 regularization and losses using absolute values.

## Validation

- `uv run pytest tests/test_tensor.py`
- `uv run pytest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized autograd addition with a focused test; no auth, I/O, or broad API changes beyond fixing gradient flow for absolute value.
> 
> **Overview**
> **`abs(Tensor)` now participates in autograd** instead of returning a leaf with no computation graph.
> 
> A new **`Abs`** op forwards with `np.abs` and backprops **`sign(x)`**, using subgradient **0 at x == 0**. **`Tensor.__abs__`** follows the same tracking pattern as other unary ops (`tanh`, etc.): when gradients are enabled it records a **`Function(Abs, …)`** context.
> 
> A regression test checks **`abs(x).sum().backward()`** for negative, zero, and positive values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c84d9b0725fab8b5bc7cd47fd3555c7c9d63913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->