### PR TITLE
Fix dtype cast grad semantics

### DIFF
--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -459,8 +459,22 @@ class Tensor:
     """
 
     def float(self):
-        self.data = self.data.astype(np.float32)
-        return self
+        from punytorch.ops import Function
+
+        class FloatCast:
+            @staticmethod
+            def forward(x):
+                return x.astype(np.float32)
+
+            @staticmethod
+            def backward(context, grad):
+                return (np.asarray(grad, dtype=np.float64),)
+
+        track = Tensor._should_track(self)
+        result = Tensor(FloatCast.forward(self.data), requires_grad=track)
+        if track:
+            result.context = Function(FloatCast, self)
+        return result
 
     """
     CUSTOM METHODS FOR GENERATE FUNCTION
@@ -483,9 +497,7 @@ class Tensor:
         """
         Converts the tensor to a 64-bit integer tensor.
         """
-        if self.dtype is not np.int64:
-            return Tensor(self.data.astype(np.int64), requires_grad=self.requires_grad)
-        return self
+        return Tensor(self.data.astype(np.int64), requires_grad=False)
 
     def to(self, device):
         """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -49,3 +49,55 @@ def test_getitem_repeated_index_backward_accumulates():
     y.backward()
 
     np.testing.assert_allclose(x.grad, [0.0, 2.0, 0.0, 1.0])
+
+
+def test_float_returns_new_tensor_without_mutating_source():
+    x = Tensor(np.array([1.0, 2.0], dtype=np.float64), requires_grad=True)
+
+    y = x.float()
+
+    assert y is not x
+    assert x.data.dtype == np.float64
+    assert y.data.dtype == np.float32
+    assert y.requires_grad
+
+
+def test_float_cast_backpropagates_when_grad_enabled():
+    x = Tensor(np.array([1.0, 2.0], dtype=np.float64), requires_grad=True)
+
+    y = (x.float() * Tensor([2.0, 3.0])).sum()
+    y.backward()
+
+    np.testing.assert_allclose(x.grad, [2.0, 3.0])
+
+
+def test_float_respects_no_grad_when_casting():
+    x = Tensor(np.array([1.0, 2.0], dtype=np.float64), requires_grad=True)
+
+    with Tensor.no_grad():
+        y = x.float()
+
+    assert not y.requires_grad
+    assert y.context is None
+
+
+def test_long_returns_detached_int64_tensor():
+    x = Tensor(np.array([1.2, 2.8], dtype=np.float64), requires_grad=True)
+
+    y = x.long()
+
+    assert y is not x
+    assert x.data.dtype == np.float64
+    assert y.data.dtype == np.int64
+    assert not y.requires_grad
+    assert y.grad is None
+
+
+def test_long_detaches_existing_int64_tensor():
+    x = Tensor(np.array([1, 2], dtype=np.int64), requires_grad=True)
+
+    y = x.long()
+
+    assert y is not x
+    assert y.data.dtype == np.int64
+    assert not y.requires_grad


### PR DESCRIPTION
## Summary

- Make `Tensor.float()` return a new cast tensor instead of mutating the source tensor in place.
- Preserve gradient flow through float casts when grad tracking is enabled, while respecting `Tensor.no_grad()`.
- Make `Tensor.long()` always return detached `int64` data so integer/index tensors do not carry autograd state.

## Root Cause

The dtype helpers had mismatched autograd semantics: `.float()` mutated the existing tensor, while `.long()` created a new tensor that could preserve `requires_grad=True`. That made integer token/index tensors behave like gradient-tracked data and made float casting surprising for callers holding the original tensor.

## Validation

- `uv run pytest tests/test_tensor.py`
- `uv run pytest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tensor dtype APIs and autograd wiring used in training paths (e.g. MNIST `.float()`), though behavior is narrowed to safer semantics and covered by new tests.
> 
> **Overview**
> Fixes inconsistent dtype-cast behavior on `Tensor` so casts match typical autograd expectations.
> 
> **`float()`** no longer mutates the source tensor’s storage. It returns a new `float32` tensor wired through a small `FloatCast` op so gradients flow back to the input when tracking is on, and it honors `Tensor.no_grad()` (no `requires_grad`, no `context`).
> 
> **`long()`** always returns a new `int64` tensor with `requires_grad=False`, including when the input is already `int64`, so index/label-style tensors do not keep autograd state.
> 
> Adds tests in `tests/test_tensor.py` for non-mutation, float backprop, `no_grad`, and long detachment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad332f29e8e1c41aacff929d4294405e6fcf9459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->