### PR TITLE
Add n-gram language model core ops

### DIFF
--- a/punytorch/ops.py
+++ b/punytorch/ops.py
@@ -250,6 +250,42 @@ class Tanh(Operation):
         return (grad_tanh * grad_data,)
 
 
+class Exp(Operation):
+    @staticmethod
+    def forward(x):
+        """
+        z = exp(x)
+        """
+        return np.exp(x)
+
+    @staticmethod
+    def backward(context, grad):
+        """
+        d(exp(x))/dx = exp(x)
+        """
+        x = context.args[0]
+        grad_data = np.asarray(grad, dtype=np.float64)
+        return (grad_data * np.exp(x.data),)
+
+
+class Log(Operation):
+    @staticmethod
+    def forward(x):
+        """
+        z = log(x)
+        """
+        return np.log(x)
+
+    @staticmethod
+    def backward(context, grad):
+        """
+        d(log(x))/dx = 1 / x
+        """
+        x = context.args[0]
+        grad_data = np.asarray(grad, dtype=np.float64)
+        return (grad_data / x.data,)
+
+
 class Abs(Operation):
     @staticmethod
     def forward(x):
@@ -266,6 +302,32 @@ class Abs(Operation):
         x = context.args[0]
         grad_data = np.asarray(grad, dtype=np.float64)
         return (grad_data * np.sign(x.data),)
+
+
+class Gather(Operation):
+    @staticmethod
+    def forward(x, index):
+        """
+        Selects entries from x using NumPy indexing semantics.
+        """
+        return x[index]
+
+    @staticmethod
+    def backward(context, grad):
+        """
+        Scatters upstream gradients back into the source tensor.
+
+        Repeated indices accumulate gradient, matching embedding-table lookup
+        behavior.
+        """
+        x, index = context.args
+        grad_input = np.zeros_like(x.data, dtype=np.float64)
+        grad_data = np.asarray(grad, dtype=np.float64)
+        try:
+            np.add.at(grad_input, index, grad_data)
+        except TypeError:
+            grad_input[index] += grad_data
+        return grad_input, None
 
 
 class Transpose(Operation):
@@ -537,3 +599,43 @@ class Max(Operation):
 
         grad_output = grad_broadcast * max_mask / num_max_elements
         return grad_output, None, None
+
+
+class LogSumExp(Operation):
+    """
+    Implements a numerically stable log-sum-exp reduction.
+    """
+
+    @staticmethod
+    def forward(x, axis=None, keepdims=False):
+        """
+        Computes log(sum(exp(x))) along the selected axis or axes.
+        """
+        max_vals = np.max(x, axis=axis, keepdims=True)
+        shifted = x - max_vals
+        result = np.log(np.sum(np.exp(shifted), axis=axis, keepdims=True)) + max_vals
+
+        if keepdims:
+            return result
+        return np.squeeze(result, axis=axis)
+
+    @staticmethod
+    def backward(context, grad):
+        """
+        The gradient of logsumexp is softmax over the reduced dimension.
+        """
+        x, axis, keepdims = context.args
+        grad_data = np.asarray(grad, dtype=np.float64)
+        normalized_axis = _normalize_axis(axis, x.data.ndim)
+
+        max_vals = np.max(x.data, axis=axis, keepdims=True)
+        shifted = x.data - max_vals
+        exp_shifted = np.exp(shifted)
+        denominator = np.sum(exp_shifted, axis=axis, keepdims=True)
+        softmax = exp_shifted / denominator
+
+        if normalized_axis is not None and not keepdims:
+            for ax in sorted(normalized_axis):
+                grad_data = np.expand_dims(grad_data, axis=ax)
+
+        return softmax * grad_data, None, None

--- a/punytorch/tensor.py
+++ b/punytorch/tensor.py
@@ -7,7 +7,11 @@ from punytorch.ops import (
     Abs,
     Add,
     Cat,
+    Exp,
     Function,
+    Gather,
+    Log,
+    LogSumExp,
     MatMul,
     Max,
     Mean,
@@ -66,32 +70,10 @@ class Tensor:
 
     def __getitem__(self, index):
         index_data = index.data if isinstance(index, Tensor) else index
-        # Create a new tensor from the indexed data
         track = Tensor._should_track(self)
-        result = Tensor(self.data[index_data], requires_grad=track)
-
-        # If this tensor requires gradients, we need to set up the backward connection
+        result = Tensor(Gather.forward(self.data, index_data), requires_grad=track)
         if track:
-            # We need to create a custom indexing operation that can propagate gradients
-            class GetItem:
-                @staticmethod
-                def forward(x, index):
-                    return x[index]
-
-                @staticmethod
-                def backward(context, grad):
-                    x, index = context.args
-                    # Create a gradient tensor of the same shape as the original
-                    grad_input = np.zeros_like(x.data, dtype=np.float64)
-                    # Place the gradient at the indexed location
-                    grad_data = np.asarray(grad, dtype=np.float64)
-                    try:
-                        np.add.at(grad_input, index, grad_data)
-                    except TypeError:
-                        grad_input[index] += grad_data
-                    return grad_input, None
-
-            result.context = Function(GetItem, self, index_data)
+            result.context = Function(Gather, self, index_data)
 
         return result
 
@@ -308,6 +290,16 @@ class Tensor:
             result.context = Function(Max, self, axis, keepdims)
         return result
 
+    def logsumexp(self, axis=None, keepdims=False):
+        """
+        Returns log(sum(exp(x))) along the specified axis using a stable reduction.
+        """
+        track = Tensor._should_track(self)
+        result = Tensor(LogSumExp.forward(self.data, axis, keepdims), requires_grad=track)
+        if track:
+            result.context = Function(LogSumExp, self, axis, keepdims)
+        return result
+
     """
     BINARY OPS
     """
@@ -413,6 +405,23 @@ class Tensor:
         if track:
             result.context = Function(Tanh, self)
         return result
+
+    def exp(self):
+        track = Tensor._should_track(self)
+        result = Tensor(Exp.forward(self.data), requires_grad=track)
+        if track:
+            result.context = Function(Exp, self)
+        return result
+
+    def log(self):
+        track = Tensor._should_track(self)
+        result = Tensor(Log.forward(self.data), requires_grad=track)
+        if track:
+            result.context = Function(Log, self)
+        return result
+
+    def gather(self, index):
+        return self[index]
 
     # TODO: implement new argmax function
 

--- a/tests/test_gradcheck.py
+++ b/tests/test_gradcheck.py
@@ -178,12 +178,37 @@ def test_reshape_gradcheck():
 @pytest.mark.parametrize(
     ("fn", "inputs", "upstream"),
     [
+        (lambda x: x.exp(), ([-1.5, -0.2, 0.4, 2.0],), [0.5, -1.0, 1.5, 0.25]),
+        (lambda x: x.log(), ([0.5, 1.2, 2.0, 3.5],), [0.5, -1.0, 1.5, 0.25]),
         (lambda x: x.relu(), ([-1.5, -0.2, 0.4, 2.0],), [0.5, -1.0, 1.5, 0.25]),
         (lambda x: x.sigmoid(), ([-1.5, -0.2, 0.4, 2.0],), [0.5, -1.0, 1.5, 0.25]),
     ],
 )
 def test_activation_gradcheck(fn, inputs, upstream):
     assert_gradcheck(fn, inputs, upstream=upstream)
+
+
+def test_logsumexp_scalar_gradcheck():
+    assert_gradcheck(
+        lambda x: x.logsumexp(),
+        ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],),
+    )
+
+
+def test_logsumexp_axis_gradcheck():
+    assert_gradcheck(
+        lambda x: x.logsumexp(axis=1),
+        ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],),
+        upstream=[0.5, -1.5],
+    )
+
+
+def test_logsumexp_keepdims_gradcheck():
+    assert_gradcheck(
+        lambda x: x.logsumexp(axis=1, keepdims=True),
+        ([[1.0, -2.0, 0.5], [3.0, -1.5, 2.0]],),
+        upstream=[[0.5], [-1.5]],
+    )
 
 
 def test_cross_entropy_2d_logits_gradcheck():

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -51,6 +51,41 @@ def test_getitem_repeated_index_backward_accumulates():
     np.testing.assert_allclose(x.grad, [0.0, 2.0, 0.0, 1.0])
 
 
+def test_gather_matches_indexing_and_backpropagates():
+    weights = Tensor(
+        np.array(
+            [
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [5.0, 6.0],
+            ]
+        ),
+        requires_grad=True,
+    )
+    indices = Tensor(np.array([[0, 2], [1, 0]], dtype=np.int64))
+
+    gathered = weights.gather(indices)
+
+    np.testing.assert_allclose(
+        gathered.data,
+        [
+            [[1.0, 2.0], [5.0, 6.0]],
+            [[3.0, 4.0], [1.0, 2.0]],
+        ],
+    )
+
+    gathered.sum().backward()
+
+    np.testing.assert_allclose(
+        weights.grad,
+        [
+            [2.0, 2.0],
+            [1.0, 1.0],
+            [1.0, 1.0],
+        ],
+    )
+
+
 def test_abs_backward_uses_sign_subgradient():
     x = Tensor(np.array([-2.0, 0.0, 3.0]), requires_grad=True)
 


### PR DESCRIPTION
## Summary
- add autograd-backed Tensor exp, log, and stable logsumexp reductions
- promote indexed lookup into a shared Gather op and expose Tensor.gather for embedding-style selection
- add gradcheck coverage for the smooth ops and scatter-gradient coverage for gather

## Validation
- UV_CACHE_DIR=/private/tmp/uv-cache-punytorch uv run pytest -q tests/test_gradcheck.py tests/test_tensor.py tests/test_ops.py
- UV_CACHE_DIR=/private/tmp/uv-cache-punytorch uv run pytest -q -m "not dataset"
- UV_CACHE_DIR=/private/tmp/uv-cache-punytorch uv run black --check punytorch/ops.py punytorch/tensor.py tests/test_gradcheck.py tests/test_tensor.py
- git diff --check

Note: a broad Black check over all tests still reports pre-existing formatting drift in tests/conftest.py and tests/test_mnist.py, which this PR leaves untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core autograd ops and refactors indexing backward; mistakes could affect any model using indexing or log-space reductions, but scope is localized and well covered by tests.
> 
> **Overview**
> Adds **autograd-backed** `exp`, `log`, and numerically stable **`logsumexp`** on `Tensor`, implemented as new `Operation` classes in `ops.py` with softmax-style backward for `logsumexp`.
> 
> **Indexing** now routes through a shared **`Gather`** op (scatter-add backward for repeated indices) instead of an inline `GetItem` class; **`Tensor.gather`** is a thin alias for `__getitem__`.
> 
> Tests extend **gradcheck** for `exp`/`log`/`logsumexp` (scalar, axis, `keepdims`) and add a **gather** forward/backward test for embedding-style lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4124d2a10254e819050a343b7f52b1fc8458443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->